### PR TITLE
add text lable to failing doctest

### DIFF
--- a/src/utils/arrangement.rs
+++ b/src/utils/arrangement.rs
@@ -318,7 +318,7 @@ fn find_columns_less_than_average(
 /// A column is allowed to have a width 10 characters.
 /// A cell's content looks like this `sometest sometest`, which is 17 chars wide.
 /// After splitting at the default delimiter (space), it looks like this:
-/// ```
+/// ```text
 /// sometest
 /// sometest
 /// ```


### PR DESCRIPTION
When I cloned the repo this was the only test that failed. Quick fix by adding the text tag to the code block.