### PR TITLE
Add Table::lines() -> impl Iterator<Item = String> method

### DIFF
--- a/src/table.rs
+++ b/src/table.rs
@@ -71,7 +71,8 @@ impl Table {
     pub fn trim_fmt(&self) -> String {
         self.lines()
             .map(|line| line.trim_end().to_string())
-            .collect::<Vec<_>>().join("\n")
+            .collect::<Vec<_>>()
+            .join("\n")
     }
 
     /// This is an alternative to `fmt`, but rather returns an iterator to each line, rather than

--- a/src/table.rs
+++ b/src/table.rs
@@ -84,6 +84,13 @@ impl Table {
         lines.join("\n")
     }
 
+    /// This is an alternative to `fmt`, but rather returns an iterator to each line.
+    pub fn lines(&self) -> impl Iterator<Item = String> {
+        let display_info = arrange_content(self);
+        let content = format_content(&self, &display_info);
+        draw_borders(&self, content, &display_info).into_iter()
+    }
+
     /// Set the header row of the table. This is usually the title of each column.\
     /// There'll be no header unless you explicitly set it with this function.
     ///

--- a/src/table.rs
+++ b/src/table.rs
@@ -80,7 +80,7 @@ impl Table {
     pub fn lines(&self) -> impl Iterator<Item = String> {
         let display_info = arrange_content(self);
         let content = format_content(&self, &display_info);
-        draw_borders(&self, content, &display_info).into_iter()
+        draw_borders(self, content, &display_info).into_iter()
     }
 
     /// Set the header row of the table. This is usually the title of each column.\

--- a/src/table.rs
+++ b/src/table.rs
@@ -36,11 +36,7 @@ pub struct Table {
 
 impl fmt::Display for Table {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let display_info = arrange_content(self);
-        let content = format_content(&self, &display_info);
-        let lines = draw_borders(&self, content, &display_info);
-
-        write!(f, "{}", lines.join("\n"))
+        write!(f, "{}", self.lines().collect::<Vec<_>>().join("\n"))
     }
 }
 
@@ -73,18 +69,13 @@ impl Table {
     /// This is an alternative `fmt` function, which simply removes any trailing whitespaces.
     /// Trailing whitespaces often occur, when using tables without a right border.
     pub fn trim_fmt(&self) -> String {
-        let display_info = arrange_content(self);
-        let content = format_content(&self, &display_info);
-        let mut lines = draw_borders(&self, content, &display_info);
-        lines = lines
-            .iter()
+        self.lines()
             .map(|line| line.trim_end().to_string())
-            .collect();
-
-        lines.join("\n")
+            .collect::<Vec<_>>().join("\n")
     }
 
-    /// This is an alternative to `fmt`, but rather returns an iterator to each line.
+    /// This is an alternative to `fmt`, but rather returns an iterator to each line, rather than
+    /// one String separated by newlines.
     pub fn lines(&self) -> impl Iterator<Item = String> {
         let display_info = arrange_content(self);
         let content = format_content(&self, &display_info);

--- a/tests/simple_test.rs
+++ b/tests/simple_test.rs
@@ -77,3 +77,27 @@ fn single_column_table() {
 +-----------+";
     assert_eq!("\n".to_string() + &table.to_string(), expected);
 }
+
+#[test]
+fn lines() {
+    let mut t = Table::new();
+    t.set_header(&["heading 1", "heading 2", "heading 3"]);
+    t.add_row(&["test 1,1", "test 1,2", "test 1,3"]);
+    t.add_row(&["test 2,1", "test 2,2", "test 2,3"]);
+    t.add_row(&["test 3,1", "test 3,2", "test 3,3"]);
+
+    let actual = t.lines();
+    let expected = &[
+        "+-----------+-----------+-----------+",
+        "| heading 1 | heading 2 | heading 3 |",
+        "+===================================+",
+        "| test 1,1  | test 1,2  | test 1,3  |",
+        "|-----------+-----------+-----------|",
+        "| test 2,1  | test 2,2  | test 2,3  |",
+        "|-----------+-----------+-----------|",
+        "| test 3,1  | test 3,2  | test 3,3  |",
+        "+-----------+-----------+-----------+",
+    ];
+
+    assert_eq!(actual.collect::<Vec<String>>(), expected);
+}


### PR DESCRIPTION
Add a public method, `Table::lines(&self) -> impl Iterator<Item = String>`, which returns each line of the table.

See #35 for rationale