### PR TITLE
Rust 2021 edition

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,9 +15,9 @@ edition = "2021"
 maintenance = { status="actively-developed" }
 
 [dependencies]
-crossterm = { version="0.20", optional=true }
-strum = "0.21"
-strum_macros = "0.21"
+crossterm = { version="0.22", optional=true }
+strum = "0.22"
+strum_macros = "0.22"
 unicode-width = "0.1"
 
 
@@ -26,7 +26,7 @@ default = ["tty"]
 tty = ["crossterm"]
 
 [dev-dependencies]
-pretty_assertions = "0.7"
+pretty_assertions = "1"
 doc-comment = "0.3"
 proptest = "1"
 criterion = "0.3"


### PR DESCRIPTION
Update the project to the new rust 2021 edition.

Bump dependencies while at it.