### PR TITLE
Refactor/naming

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ fn main() {
         .load_preset(UTF8_FULL)
         .apply_modifier(UTF8_ROUND_CORNERS)
         .set_content_arrangement(ContentArrangement::Dynamic)
-        .set_table_width(40)
+        .set_width(40)
         .set_header(vec!["Header1", "Header2", "Header3"])
         .add_row(vec![
                  Cell::new("Center aligned").set_alignment(CellAlignment::Center),
@@ -133,7 +133,7 @@ fn main() {
     let mut table = Table::new();
     table.load_preset(UTF8_FULL)
         .set_content_arrangement(ContentArrangement::Dynamic)
-        .set_table_width(80)
+        .set_width(80)
         .set_header(vec![
                     Cell::new("Header1").add_attribute(Attribute::Bold),
                     Cell::new("Header2").fg(Color::Green),
@@ -205,7 +205,7 @@ Furthermore, all terminal related functionality, including styling, can be disab
 Without this flag no `unsafe` code is used as far as I know.
 
 1. `crossterm::tty::IsTty`. This function is necessary to detect whether we're currently on a tty or not.
-    This is only called if no explicit width is provided via `Table::set_table_width`.
+    This is only called if no explicit width is provided via `Table::set_width`.
     ```rust,ignore
     /// On unix the `isatty()` function returns true if a file
     /// descriptor is a terminal.
@@ -218,7 +218,7 @@ Without this flag no `unsafe` code is used as far as I know.
     }
     ```
 2. `crossterm::terminal::size`. This function is necessary to detect the current terminal width if we're on a tty.
-    This is only called if no explicit width is provided via `Table::set_table_width`.
+    This is only called if no explicit width is provided via `Table::set_width`.
 
     http://rosettacode.org/wiki/Terminal_control/Dimensions#Library:_BSD_libc
     This is another libc call which is used to communicate with `/dev/tty` via a file descriptor.

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ fn main() {
         ]);
 
     // Set the default alignment for the third column to right
-    let column = table.get_column_mut(2).expect("Our table has three columns");
+    let column = table.column_mut(2).expect("Our table has three columns");
     column.set_cell_alignment(CellAlignment::Right);
 
     println!("{}", table);

--- a/benches/build_tables.rs
+++ b/benches/build_tables.rs
@@ -11,7 +11,7 @@ fn build_readme_table() {
     let mut table = Table::new();
     table.load_preset(UTF8_FULL)
         .set_content_arrangement(ContentArrangement::Dynamic)
-        .set_table_width(80)
+        .set_width(80)
         .set_header(vec![
             Cell::new("Header1").add_attribute(Attribute::Bold),
             Cell::new("Header2").fg(Color::Green),
@@ -43,7 +43,7 @@ fn build_readme_table() {
     let mut table = Table::new();
     table.load_preset(UTF8_FULL)
         .set_content_arrangement(ContentArrangement::Dynamic)
-        .set_table_width(80)
+        .set_width(80)
         .set_header(vec![
             Cell::new("Header1"),
             Cell::new("Header2"),
@@ -71,7 +71,7 @@ fn build_huge_table() {
     table
         .load_preset(UTF8_FULL)
         .set_content_arrangement(ContentArrangement::DynamicFullWidth)
-        .set_table_width(400)
+        .set_width(400)
         .set_header(vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
 
     // Create a 10x10 grid

--- a/examples/readme_table.rs
+++ b/examples/readme_table.rs
@@ -5,7 +5,7 @@ fn main() {
     let mut table = Table::new();
     table.load_preset(UTF8_FULL)
         .set_content_arrangement(ContentArrangement::Dynamic)
-        .set_table_width(80)
+        .set_width(80)
         .set_header(vec![
             Cell::new("Header1").add_attribute(Attribute::Bold),
             Cell::new("Header2").fg(Color::Green),

--- a/examples/readme_table_no_tty.rs
+++ b/examples/readme_table_no_tty.rs
@@ -8,7 +8,7 @@ fn main() {
     let mut table = Table::new();
     table.load_preset(UTF8_FULL)
         .set_content_arrangement(ContentArrangement::Dynamic)
-        .set_table_width(80)
+        .set_width(80)
         .set_header(vec![
             Cell::new("Header1"),
             Cell::new("Header2"),

--- a/src/cell.rs
+++ b/src/cell.rs
@@ -44,7 +44,7 @@ impl Cell {
     }
 
     /// Return a copy of the content contained in this cell.
-    pub fn get_content(&self) -> String {
+    pub fn content(&self) -> String {
         self.content.join("\n")
     }
 
@@ -192,6 +192,6 @@ mod tests {
         let content = "This is\nsome multiline\nstring".to_string();
         let cell = Cell::new(content.clone());
 
-        assert_eq!(cell.get_content(), content);
+        assert_eq!(cell.content(), content);
     }
 }

--- a/src/column.rs
+++ b/src/column.rs
@@ -16,7 +16,7 @@ use crate::style::{CellAlignment, ColumnConstraint};
 /// let mut table = Table::new();
 /// table.set_header(&vec!["one", "two"]);
 ///
-/// let mut column = table.get_column_mut(1).expect("This should be column two");
+/// let mut column = table.column_mut(1).expect("This should be column two");
 ///
 /// // Set the max width for all cells of this column to 20 characters.
 /// column.set_constraint(UpperBoundary(Fixed(20)));
@@ -65,7 +65,7 @@ impl Column {
     }
 
     /// Internal convenience helper that returns the total width of the combined padding.
-    pub(crate) fn get_padding_width(&self) -> u16 {
+    pub(crate) fn padding_width(&self) -> u16 {
         self.padding.0 + self.padding.1
     }
 
@@ -82,13 +82,13 @@ impl Column {
 
     /// Get the width in characters of the widest line in this column.\
     /// This doesn't include padding yet!
-    pub fn get_max_content_width(&self) -> u16 {
+    pub fn max_content_width(&self) -> u16 {
         self.max_content_width
     }
 
     /// Get the maximum possible width for this column.\
     /// This means widest line in this column + padding
-    pub fn get_max_width(&self) -> u16 {
+    pub fn max_width(&self) -> u16 {
         self.max_content_width + self.padding.0 + self.padding.1
     }
 
@@ -101,7 +101,7 @@ impl Column {
     }
 
     /// Get the constraint that is used for this column.
-    pub fn get_constraint(&self) -> Option<&ColumnConstraint> {
+    pub fn constraint(&self) -> Option<&ColumnConstraint> {
         self.constraint.as_ref()
     }
 
@@ -132,15 +132,12 @@ mod tests {
     fn test_column() {
         let mut column = Column::new(0);
         column.set_padding((0, 0));
-        assert_eq!(column.get_max_content_width(), 0);
+        assert_eq!(column.max_content_width(), 0);
 
         column.set_constraint(ColumnConstraint::ContentWidth);
-        assert_eq!(
-            column.get_constraint(),
-            Some(&ColumnConstraint::ContentWidth)
-        );
+        assert_eq!(column.constraint(), Some(&ColumnConstraint::ContentWidth));
 
         column.remove_constraint();
-        assert_eq!(column.get_constraint(), None);
+        assert_eq!(column.constraint(), None);
     }
 }

--- a/src/row.rs
+++ b/src/row.rs
@@ -142,7 +142,7 @@ mod tests {
         let mut cell_content_iter = cells.iter();
         for cell in row.cell_iter() {
             assert_eq!(
-                cell.get_content(),
+                cell.content(),
                 cell_content_iter.next().unwrap().to_string()
             );
         }

--- a/src/style/table.rs
+++ b/src/style/table.rs
@@ -20,7 +20,7 @@ pub enum ContentArrangement {
     /// Constraints on columns are still respected.
     ///
     /// **Warning:** If terminal width cannot be determined and no table_width is set via
-    /// [Table::set_table_width](crate::table::Table::set_table_width),
+    /// [Table::set_width](crate::table::Table::set_width),
     /// this option won't work and [Disabled](ContentArrangement::Disabled) will be used as a fallback.
     Dynamic,
     /// This is mode is the same as the [ContentArrangement::Dynamic] arrangement, but it will always use as much

--- a/src/table.rs
+++ b/src/table.rs
@@ -32,7 +32,7 @@ pub struct Table {
     no_tty: bool,
     #[cfg(feature = "tty")]
     use_stderr: bool,
-    table_width: Option<u16>,
+    width: Option<u16>,
     enforce_styling: bool,
 }
 
@@ -60,7 +60,7 @@ impl Table {
             no_tty: false,
             #[cfg(feature = "tty")]
             use_stderr: false,
-            table_width: None,
+            width: None,
             style: HashMap::new(),
             enforce_styling: false,
         };
@@ -130,25 +130,25 @@ impl Table {
     /// Enforce a max width that should be used in combination with [dynamic content arrangement](ContentArrangement::Dynamic).\
     /// This is usually not necessary, if you plan to output your table to a tty,
     /// since the terminal width can be automatically determined.
-    pub fn set_table_width(&mut self, table_width: u16) -> &mut Self {
-        self.table_width = Some(table_width);
+    pub fn set_width(&mut self, width: u16) -> &mut Self {
+        self.width = Some(width);
 
         self
     }
 
     /// Get the expected width of the table.
     ///
-    /// This will be `Some(width)`, if the terminal width can be detected or if the table width is set via [set_table_width](Table::set_table_width).
+    /// This will be `Some(width)`, if the terminal width can be detected or if the table width is set via [set_width](Table::set_width).
     ///
     /// If neither is not possible, `None` will be returned.\
     /// This implies that both the [Dynamic](ContentArrangement::Dynamic) mode and the [Percentage](crate::style::ColumnConstraint::Percentage) constraint won't work.
     #[cfg(feature = "tty")]
-    pub fn table_width(&self) -> Option<u16> {
-        if let Some(width) = self.table_width {
+    pub fn width(&self) -> Option<u16> {
+        if let Some(width) = self.width {
             Some(width)
         } else if self.is_tty() {
-            if let Ok((table_width, _)) = terminal::size() {
-                Some(table_width)
+            if let Ok((width, _)) = terminal::size() {
+                Some(width)
             } else {
                 None
             }
@@ -158,8 +158,8 @@ impl Table {
     }
 
     #[cfg(not(feature = "tty"))]
-    pub fn table_width(&self) -> Option<u16> {
-        self.table_width
+    pub fn width(&self) -> Option<u16> {
+        self.width
     }
 
     /// Specify how Comfy Table should arrange the content in your table.
@@ -192,11 +192,11 @@ impl Table {
     ///
     /// This disables:
     ///
-    /// - table_width lookup from the current tty
+    /// - width lookup from the current tty
     /// - Styling and attributes on cells (unless you use [Table::enforce_styling])
     ///
     /// If you use the [dynamic content arrangement](ContentArrangement::Dynamic),
-    /// you need to set the width of your desired table manually with [set_table_width](Table::set_table_width).
+    /// you need to set the width of your desired table manually with [set_width](Table::set_width).
     pub fn force_no_tty(&mut self) -> &mut Self {
         self.no_tty = true;
 
@@ -434,7 +434,7 @@ impl Table {
     /// use comfy_table::TableComponent::*;
     ///
     /// let mut table = Table::new();
-    /// assert_eq!(table.get_style(TopLeftCorner), Some('+'));
+    /// assert_eq!(table.style(TopLeftCorner), Some('+'));
     /// ```
 
     pub fn style(&mut self, component: TableComponent) -> Option<char> {
@@ -506,9 +506,9 @@ impl Table {
     ///
     /// // Create an iterator over the second column
     /// let mut cell_iter = table.column_cells_iter(1);
-    /// assert_eq!(cell_iter.next().unwrap().unwrap().get_content(), "Second");
+    /// assert_eq!(cell_iter.next().unwrap().unwrap().content(), "Second");
     /// assert!(cell_iter.next().unwrap().is_none());
-    /// assert_eq!(cell_iter.next().unwrap().unwrap().get_content(), "Fifth");
+    /// assert_eq!(cell_iter.next().unwrap().unwrap().content(), "Fifth");
     /// assert!(cell_iter.next().is_none());
     /// ```
     pub fn column_cells_iter(&self, column_index: usize) -> ColumnCellIter {

--- a/src/table.rs
+++ b/src/table.rs
@@ -105,7 +105,7 @@ impl Table {
         self
     }
 
-    pub fn get_header(&self) -> Option<&Row> {
+    pub fn header(&self) -> Option<&Row> {
         self.header.as_ref()
     }
 
@@ -143,7 +143,7 @@ impl Table {
     /// If neither is not possible, `None` will be returned.\
     /// This implies that both the [Dynamic](ContentArrangement::Dynamic) mode and the [Percentage](crate::style::ColumnConstraint::Percentage) constraint won't work.
     #[cfg(feature = "tty")]
-    pub fn get_table_width(&self) -> Option<u16> {
+    pub fn table_width(&self) -> Option<u16> {
         if let Some(width) = self.table_width {
             Some(width)
         } else if self.is_tty() {
@@ -158,7 +158,7 @@ impl Table {
     }
 
     #[cfg(not(feature = "tty"))]
-    pub fn get_table_width(&self) -> Option<u16> {
+    pub fn table_width(&self) -> Option<u16> {
         self.table_width
     }
 
@@ -349,7 +349,7 @@ impl Table {
         let mut preset_string = String::new();
 
         for component in components {
-            match self.get_style(component) {
+            match self.style(component) {
                 None => preset_string.push(' '),
                 Some(character) => preset_string.push(character),
             }
@@ -437,7 +437,7 @@ impl Table {
     /// assert_eq!(table.get_style(TopLeftCorner), Some('+'));
     /// ```
 
-    pub fn get_style(&mut self, component: TableComponent) -> Option<char> {
+    pub fn style(&mut self, component: TableComponent) -> Option<char> {
         self.style.get(&component).copied()
     }
 
@@ -451,12 +451,12 @@ impl Table {
     }
 
     /// Get a reference to a specific column.
-    pub fn get_column(&self, index: usize) -> Option<&Column> {
+    pub fn column(&self, index: usize) -> Option<&Column> {
         self.columns.get(index)
     }
 
     /// Get a mutable reference to a specific column.
-    pub fn get_column_mut(&mut self, index: usize) -> Option<&mut Column> {
+    pub fn column_mut(&mut self, index: usize) -> Option<&mut Column> {
         self.columns.get_mut(index)
     }
 
@@ -520,12 +520,12 @@ impl Table {
     }
 
     /// Reference to a specific row
-    pub fn get_row(&self, index: usize) -> Option<&Row> {
+    pub fn row(&self, index: usize) -> Option<&Row> {
         self.rows.get(index)
     }
 
     /// Mutable reference to a specific row
-    pub fn get_row_mut(&mut self, index: usize) -> Option<&mut Row> {
+    pub fn row_mut(&mut self, index: usize) -> Option<&mut Row> {
         self.rows.get_mut(index)
     }
 

--- a/src/utils/arrangement/constraint.rs
+++ b/src/utils/arrangement/constraint.rs
@@ -41,8 +41,7 @@ pub fn evaluate(
         _ => {}
     }
 
-    if let Some(min_width) = min_constraint(table, &column.constraint, table_width, visible_columns)
-    {
+    if let Some(min_width) = min(table, &column.constraint, table_width, visible_columns) {
         // In case a min_width is specified, we may already fix the size of the column.
         // We do this, if we know that the content is smaller than the min size.
         if column.max_width() <= min_width {
@@ -60,7 +59,7 @@ pub fn evaluate(
 /// Lower boundaries with [Width::Fixed] just return their internal value. \
 /// Lower boundaries with [Width::Percentage] return the percental amount of the current table
 /// width.
-pub fn min_constraint(
+pub fn min(
     table: &Table,
     constraint: &Option<ColumnConstraint>,
     table_width: Option<usize>,
@@ -87,7 +86,7 @@ pub fn min_constraint(
 /// Upper boundaries with [Width::Fixed] just return their internal value. \
 /// Upper boundaries with [Width::Percentage] return the percental amount of the current table
 /// width.
-pub fn max_constraint(
+pub fn max(
     table: &Table,
     constraint: &Option<ColumnConstraint>,
     table_width: Option<usize>,

--- a/src/utils/arrangement/constraints.rs
+++ b/src/utils/arrangement/constraints.rs
@@ -41,12 +41,11 @@ pub fn evaluate(
         _ => {}
     }
 
-    if let Some(min_width) =
-        get_min_constraint(table, &column.constraint, table_width, visible_columns)
+    if let Some(min_width) = min_constraint(table, &column.constraint, table_width, visible_columns)
     {
         // In case a min_width is specified, we may already fix the size of the column.
         // We do this, if we know that the content is smaller than the min size.
-        if column.get_max_width() <= min_width {
+        if column.max_width() <= min_width {
             let width = absolute_width_with_padding(column, min_width);
             let info = ColumnDisplayInfo::new(column, width);
             infos.insert(column.index, info);
@@ -61,7 +60,7 @@ pub fn evaluate(
 /// Lower boundaries with [Width::Fixed] just return their internal value. \
 /// Lower boundaries with [Width::Percentage] return the percental amount of the current table
 /// width.
-pub fn get_min_constraint(
+pub fn min_constraint(
     table: &Table,
     constraint: &Option<ColumnConstraint>,
     table_width: Option<usize>,
@@ -88,7 +87,7 @@ pub fn get_min_constraint(
 /// Upper boundaries with [Width::Fixed] just return their internal value. \
 /// Upper boundaries with [Width::Percentage] return the percental amount of the current table
 /// width.
-pub fn get_max_constraint(
+pub fn max_constraint(
     table: &Table,
     constraint: &Option<ColumnConstraint>,
     table_width: Option<usize>,

--- a/src/utils/arrangement/disabled.rs
+++ b/src/utils/arrangement/disabled.rs
@@ -1,4 +1,4 @@
-use super::constraints::get_max_constraint;
+use super::constraints::max_constraint;
 use super::helper::*;
 use super::{ColumnDisplayInfo, DisplayInfos};
 use crate::Table;
@@ -12,12 +12,10 @@ pub fn arrange(table: &Table, infos: &mut DisplayInfos, visible_columns: usize) 
             continue;
         }
 
-        let mut width = column.get_max_content_width();
+        let mut width = column.max_content_width();
 
         // Reduce the width, if a column has longer content than the specified MaxWidth constraint.
-        if let Some(max_width) =
-            get_max_constraint(table, &column.constraint, None, visible_columns)
-        {
+        if let Some(max_width) = max_constraint(table, &column.constraint, None, visible_columns) {
             if max_width < width {
                 width = absolute_width_with_padding(column, max_width);
             }

--- a/src/utils/arrangement/disabled.rs
+++ b/src/utils/arrangement/disabled.rs
@@ -1,4 +1,4 @@
-use super::constraints::max_constraint;
+use super::constraint;
 use super::helper::*;
 use super::{ColumnDisplayInfo, DisplayInfos};
 use crate::Table;
@@ -15,7 +15,7 @@ pub fn arrange(table: &Table, infos: &mut DisplayInfos, visible_columns: usize) 
         let mut width = column.max_content_width();
 
         // Reduce the width, if a column has longer content than the specified MaxWidth constraint.
-        if let Some(max_width) = max_constraint(table, &column.constraint, None, visible_columns) {
+        if let Some(max_width) = constraint::max(table, &column.constraint, None, visible_columns) {
             if max_width < width {
                 width = absolute_width_with_padding(column, max_width);
             }

--- a/src/utils/arrangement/dynamic.rs
+++ b/src/utils/arrangement/dynamic.rs
@@ -1,7 +1,6 @@
 use unicode_width::UnicodeWidthStr;
 
-use super::constraints::max_constraint;
-use super::constraints::min_constraint;
+use super::constraint;
 use super::helper::*;
 use super::{ColumnDisplayInfo, DisplayInfos};
 use crate::style::*;
@@ -223,7 +222,7 @@ fn find_columns_less_than_average(
             // two conditions are met:
             // - The average remaining space is bigger then the MaxWidth constraint.
             // - The actual max content of the column is bigger than the MaxWidth constraint.
-            if let Some(max_width) = max_constraint(
+            if let Some(max_width) = constraint::max(
                 table,
                 &column.constraint,
                 Some(table_width),
@@ -296,7 +295,7 @@ fn enforce_lower_boundary_constraints(
         }
 
         // Check whether the column has a LowerBoundary constraint.
-        let min_width = if let Some(min_width) = min_constraint(
+        let min_width = if let Some(min_width) = constraint::min(
             table,
             &column.constraint,
             Some(table_width),

--- a/src/utils/arrangement/helper.rs
+++ b/src/utils/arrangement/helper.rs
@@ -53,7 +53,7 @@ pub fn count_border_columns(table: &Table, visible_columns: usize) -> usize {
 
 /// Get the delimiter for a Cell.
 /// Priority is in decreasing order: Cell -> Column -> Table.
-pub fn get_delimiter(table: &Table, column: &Column, cell: &Cell) -> char {
+pub fn delimiter(table: &Table, column: &Column, cell: &Cell) -> char {
     // Determine, which delimiter should be used
     if let Some(delimiter) = cell.delimiter {
         delimiter

--- a/src/utils/arrangement/mod.rs
+++ b/src/utils/arrangement/mod.rs
@@ -4,7 +4,7 @@ use super::ColumnDisplayInfo;
 use crate::style::ContentArrangement;
 use crate::table::Table;
 
-mod constraints;
+mod constraint;
 mod disabled;
 mod dynamic;
 mod helper;
@@ -14,13 +14,13 @@ type DisplayInfos = BTreeMap<usize, ColumnDisplayInfo>;
 /// Determine the width of each column depending on the content of the given table.
 /// The results uses Option<usize>, since users can choose to hide columns.
 pub(crate) fn arrange_content(table: &Table) -> Vec<ColumnDisplayInfo> {
-    let table_width = table.table_width().map(usize::from);
+    let table_width = table.width().map(usize::from);
     let mut infos = BTreeMap::new();
 
     let visible_columns = helper::count_visible_columns(&table.columns);
     for column in table.columns.iter() {
         if column.constraint.is_some() {
-            constraints::evaluate(table, column, &mut infos, table_width, visible_columns);
+            constraint::evaluate(table, column, &mut infos, table_width, visible_columns);
         }
     }
     //println!("After initial constraints: {:#?}", infos);

--- a/src/utils/arrangement/mod.rs
+++ b/src/utils/arrangement/mod.rs
@@ -14,7 +14,7 @@ type DisplayInfos = BTreeMap<usize, ColumnDisplayInfo>;
 /// Determine the width of each column depending on the content of the given table.
 /// The results uses Option<usize>, since users can choose to hide columns.
 pub(crate) fn arrange_content(table: &Table) -> Vec<ColumnDisplayInfo> {
-    let table_width = table.get_table_width().map(usize::from);
+    let table_width = table.table_width().map(usize::from);
     let mut infos = BTreeMap::new();
 
     let visible_columns = helper::count_visible_columns(&table.columns);

--- a/src/utils/formatting/content_format.rs
+++ b/src/utils/formatting/content_format.rs
@@ -9,7 +9,7 @@ use crate::style::CellAlignment;
 use crate::table::Table;
 use crate::utils::ColumnDisplayInfo;
 
-pub fn get_delimiter(cell: &Cell, info: &ColumnDisplayInfo, table: &Table) -> char {
+pub fn delimiter(cell: &Cell, info: &ColumnDisplayInfo, table: &Table) -> char {
     // Determine, which delimiter should be used
     if let Some(delimiter) = cell.delimiter {
         delimiter
@@ -43,7 +43,7 @@ pub fn format_content(table: &Table, display_info: &[ColumnDisplayInfo]) -> Vec<
     let mut table_content = Vec::new();
 
     // Format table header if it exists
-    if let Some(header) = table.get_header() {
+    if let Some(header) = table.header() {
         table_content.push(format_row(header, display_info, table));
     }
 
@@ -82,7 +82,7 @@ pub fn format_row(
             continue;
         };
 
-        let delimiter = get_delimiter(cell, info, table);
+        let delimiter = delimiter(cell, info, table);
 
         // Iterate over each line and split it into multiple lines, if necessary.
         // Newlines added by the user will be preserved.

--- a/tests/all/combined_test.rs
+++ b/tests/all/combined_test.rs
@@ -6,7 +6,7 @@ fn get_preset_table() -> Table {
     let mut table = Table::new();
     table.load_preset(UTF8_FULL)
         .set_content_arrangement(ContentArrangement::Dynamic)
-        .set_table_width(80)
+        .set_width(80)
         .set_header(vec![
             Cell::new("Header1").add_attribute(Attribute::Bold),
             Cell::new("Header2").fg(Color::Green),

--- a/tests/all/constraints_test.rs
+++ b/tests/all/constraints_test.rs
@@ -60,7 +60,7 @@ fn fixed_max_min_constraints() {
     // Since the left and right column are fixed, the middle column should only get a width of 2
     table
         .set_content_arrangement(ContentArrangement::Dynamic)
-        .set_table_width(28);
+        .set_width(28);
 
     println!("{}", table);
     let expected = "
@@ -147,7 +147,7 @@ fn constraints_bigger_than_table_width() {
 
     table
         .set_content_arrangement(ContentArrangement::Dynamic)
-        .set_table_width(28)
+        .set_width(28)
         .set_constraints(vec![
             UpperBoundary(Fixed(50)),
             LowerBoundary(Fixed(30)),
@@ -186,7 +186,7 @@ fn percentage() {
     // The the rest should arrange accordingly.
     table
         .set_content_arrangement(ContentArrangement::Dynamic)
-        .set_table_width(40)
+        .set_width(40)
         .set_constraints(vec![Absolute(Percentage(20))]);
 
     println!("{}", table);
@@ -214,7 +214,7 @@ fn max_100_percentage() {
         .set_header(&vec!["smol"])
         .add_row(&vec!["smol"])
         .set_content_arrangement(ContentArrangement::Dynamic)
-        .set_table_width(40)
+        .set_width(40)
         .set_constraints(vec![Absolute(Percentage(200))]);
 
     println!("{}", table);
@@ -234,7 +234,7 @@ fn percentage_second() {
 
     table
         .set_content_arrangement(ContentArrangement::Dynamic)
-        .set_table_width(40)
+        .set_width(40)
         .set_constraints(vec![
             LowerBoundary(Percentage(40)),
             UpperBoundary(Percentage(30)),
@@ -267,7 +267,7 @@ fn max_percentage() {
 
     table
         .set_content_arrangement(ContentArrangement::Dynamic)
-        .set_table_width(40)
+        .set_width(40)
         .set_constraints(vec![
             ContentWidth,
             UpperBoundary(Percentage(30)),
@@ -301,7 +301,7 @@ fn min_max_boundary() {
 
     table
         .set_content_arrangement(ContentArrangement::Dynamic)
-        .set_table_width(40)
+        .set_width(40)
         .set_constraints(vec![
             Boundaries {
                 lower: Percentage(50),

--- a/tests/all/content_arrangement_test.rs
+++ b/tests/all/content_arrangement_test.rs
@@ -17,7 +17,7 @@ fn simple_dynamic_table() {
     let mut table = Table::new();
     table.set_header(&vec!["Header1", "Header2", "Head"])
         .set_content_arrangement(ContentArrangement::Dynamic)
-        .set_table_width(25)
+        .set_width(25)
         .add_row(&vec![
             "This is a very long line with a lot of text",
             "This is anotherverylongtextwithlongwords text",
@@ -93,7 +93,7 @@ fn table_with_truncate() {
     table
         .set_header(&vec!["Header1", "Header2", "Head"])
         .set_content_arrangement(ContentArrangement::Dynamic)
-        .set_table_width(35)
+        .set_width(35)
         .add_row(first_row)
         .add_row(second_row);
 
@@ -137,7 +137,7 @@ fn distribute_space_after_split() {
     table
         .set_header(&vec!["Header1", "Header2", "Head"])
         .set_content_arrangement(ContentArrangement::Dynamic)
-        .set_table_width(80)
+        .set_width(80)
         .add_row(&vec![
             "This is a very long line with a lot of text",
             "This is text with a anotherverylongtexttesttest",
@@ -166,7 +166,7 @@ fn unused_space_after_split() {
     table
         .set_header(&vec!["Header1"])
         .set_content_arrangement(ContentArrangement::Dynamic)
-        .set_table_width(30)
+        .set_width(30)
         .add_row(&vec!["This is text with a anotherverylongtext"]);
 
     println!("{}", table);
@@ -189,7 +189,7 @@ fn dynamic_full_width_after_split() {
     table
         .set_header(&vec!["Header1"])
         .set_content_arrangement(ContentArrangement::DynamicFullWidth)
-        .set_table_width(50)
+        .set_width(50)
         .add_row(&vec!["This is text with a anotherverylongtexttesttestaa"]);
 
     println!("{}", table);
@@ -214,7 +214,7 @@ fn dynamic_full_width() {
     table
         .set_header(&vec!["Header1", "Header2", "smol"])
         .set_content_arrangement(ContentArrangement::DynamicFullWidth)
-        .set_table_width(80)
+        .set_width(80)
         .add_row(&vec!["This is a short line", "small", "smol"]);
 
     println!("{}", table);

--- a/tests/all/content_arrangement_test.rs
+++ b/tests/all/content_arrangement_test.rs
@@ -99,11 +99,11 @@ fn table_with_truncate() {
 
     // The first column will be wider than 6 chars.
     // The second column's content is wider than 6 chars. There should be a '...'.
-    let second_column = table.get_column_mut(1).unwrap();
+    let second_column = table.column_mut(1).unwrap();
     second_column.set_constraint(Absolute(Fixed(8)));
 
     // The third column's content is less than 6 chars width. There shouldn't be a '...'.
-    let third_column = table.get_column_mut(2).unwrap();
+    let third_column = table.column_mut(2).unwrap();
     third_column.set_constraint(Absolute(Fixed(7)));
 
     println!("{}", table);

--- a/tests/all/custom_delimiter_test.rs
+++ b/tests/all/custom_delimiter_test.rs
@@ -14,7 +14,7 @@ fn full_custom_delimiters() {
         .set_header(&vec!["Header1", "Header2"])
         .set_content_arrangement(ContentArrangement::Dynamic)
         .set_delimiter('-')
-        .set_table_width(40)
+        .set_width(40)
         .add_row(&vec![
             "This shouldn't be split with any logic, since there's no matching delimiter",
             "Test-Test-Test-Test-Test-This_should_only_be_splitted_by_underscore_and not by space or hyphens",

--- a/tests/all/custom_delimiter_test.rs
+++ b/tests/all/custom_delimiter_test.rs
@@ -29,7 +29,7 @@ fn full_custom_delimiters() {
         .set_delimiter('/'),
     ]);
 
-    let column = table.get_column_mut(1).unwrap();
+    let column = table.column_mut(1).unwrap();
     column.set_delimiter('_');
 
     println!("{}", table);

--- a/tests/all/hidden_test.rs
+++ b/tests/all/hidden_test.rs
@@ -77,7 +77,7 @@ fn hidden_columns() {
 #[test]
 fn hidden_columns_with_dynamic_adjustment() {
     let mut table = get_table();
-    table.set_table_width(25);
+    table.set_width(25);
     table.set_content_arrangement(ContentArrangement::Dynamic);
 
     println!("{}", table);

--- a/tests/all/hidden_test.rs
+++ b/tests/all/hidden_test.rs
@@ -35,20 +35,20 @@ fn get_table() -> Table {
 
     // Hide the first, third and 6th column
     table
-        .get_column_mut(0)
+        .column_mut(0)
         .unwrap()
         .set_constraint(ColumnConstraint::Hidden);
     table
-        .get_column_mut(2)
+        .column_mut(2)
         .unwrap()
         .set_constraint(ColumnConstraint::Hidden);
     table
-        .get_column_mut(3)
+        .column_mut(3)
         .unwrap()
         .set_constraint(ColumnConstraint::Hidden);
 
     table
-        .get_column_mut(6)
+        .column_mut(6)
         .unwrap()
         .set_constraint(ColumnConstraint::Hidden);
 

--- a/tests/all/padding_test.rs
+++ b/tests/all/padding_test.rs
@@ -17,9 +17,9 @@ fn custom_padding() {
         .add_row(&vec!["Two One", "Two Two", "Two Three"])
         .add_row(&vec!["Three One", "Three Two", "Three Three"]);
 
-    let column = table.get_column_mut(0).unwrap();
+    let column = table.column_mut(0).unwrap();
     column.set_padding((5, 5));
-    let column = table.get_column_mut(2).unwrap();
+    let column = table.column_mut(2).unwrap();
     column.set_padding((0, 0));
 
     println!("{}", table);

--- a/tests/all/property_test.rs
+++ b/tests/all/property_test.rs
@@ -140,7 +140,7 @@ prop_compose! {
 
         }
 
-        table.set_table_width(table_width)
+        table.set_width(table_width)
             .set_content_arrangement(arrangement)
             .load_preset(UTF8_FULL)
             .apply_modifier(UTF8_ROUND_CORNERS);

--- a/tests/all/utf_8_characters.rs
+++ b/tests/all/utf_8_characters.rs
@@ -40,7 +40,7 @@ fn multi_character_utf8_symbols() {
 fn multi_character_utf8_word_splitting() {
     let mut table = Table::new();
     table
-        .set_table_width(8)
+        .set_width(8)
         .set_content_arrangement(ContentArrangement::Dynamic)
         .set_header(&vec!["test"])
         .add_row(&vec!["abc✅def"]);


### PR DESCRIPTION
**THIS IS A BREAKING CHANGE**

because it's a breaking change, it's *probably* not worth doing...

updates some of the object naming:

- it is not idiomatic in Rust to prefix getters with `get_`
- remove some 'stuttering' in object names
as in,

```rust
// impl Table
    pub fn set_table_width(&mut self, table_width: u16) -> &mut Self {
        self.table_width = Some(table_width);
    }
```

(we're namespaced under `Table` here, so it's clear what the `width` is referring to without `table_`)