### PR TITLE
remove unused imports

### DIFF
--- a/src/table.rs
+++ b/src/table.rs
@@ -1,5 +1,4 @@
 use std::collections::HashMap;
-use std::convert::TryInto;
 use std::fmt;
 use std::iter::IntoIterator;
 use std::slice::{Iter, IterMut};

--- a/src/utils/arrangement/constraints.rs
+++ b/src/utils/arrangement/constraints.rs
@@ -1,5 +1,3 @@
-use std::convert::TryInto;
-
 use super::helper::*;
 use super::{ColumnDisplayInfo, DisplayInfos};
 use crate::style::{ColumnConstraint, ColumnConstraint::*, Width};

--- a/src/utils/arrangement/dynamic.rs
+++ b/src/utils/arrangement/dynamic.rs
@@ -1,5 +1,3 @@
-use std::convert::TryInto;
-
 use unicode_width::UnicodeWidthStr;
 
 use super::constraints::get_max_constraint;

--- a/src/utils/arrangement/helper.rs
+++ b/src/utils/arrangement/helper.rs
@@ -1,5 +1,3 @@
-use std::convert::TryInto;
-
 use super::DisplayInfos;
 use crate::utils::formatting::borders::{
     should_draw_left_border, should_draw_right_border, should_draw_vertical_lines,


### PR DESCRIPTION
`TryInto` is in the `std` prelude in 2021 edition, so these imports are not required.