### PR TITLE
Add support for cells with ansi codes.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,7 @@ crossterm = { version = "0.23", optional = true }
 strum = "0.24"
 strum_macros = "0.24"
 unicode-width = "0.1"
+textwrap = "0.15"
 
 [dev-dependencies]
 pretty_assertions = "1"

--- a/src/row.rs
+++ b/src/row.rs
@@ -1,7 +1,5 @@
 use std::slice::Iter;
 
-use unicode_width::UnicodeWidthStr;
-
 use crate::cell::{Cell, Cells};
 
 /// Each row contains [Cells](crate::Cell) and can be added to a [Table](crate::Table).
@@ -63,7 +61,7 @@ impl Row {
                 // Each entry represents the longest string width for a cell.
                 cell.content
                     .iter()
-                    .map(|string| string.width())
+                    .map(|string| textwrap::core::display_width(string))
                     .max()
                     .unwrap_or(0)
             })

--- a/src/utils/arrangement/dynamic.rs
+++ b/src/utils/arrangement/dynamic.rs
@@ -1,5 +1,3 @@
-use unicode_width::UnicodeWidthStr;
-
 use super::constraint;
 use super::helper::*;
 use super::{ColumnDisplayInfo, DisplayInfos};
@@ -429,7 +427,7 @@ fn longest_line_after_split(average_space: usize, column: &Column, table: &Table
         // Iterate over each line and split it into multiple lines, if necessary.
         // Newlines added by the user will be preserved.
         for line in cell.content.iter() {
-            if line.width() > average_space {
+            if textwrap::core::display_width(line) > average_space {
                 let mut splitted = split_line(line, &info, delimiter);
                 column_lines.append(&mut splitted);
             } else {
@@ -441,7 +439,7 @@ fn longest_line_after_split(average_space: usize, column: &Column, table: &Table
     // Get the longest line, default to length 0 if no lines exist.
     column_lines
         .iter()
-        .map(|line| line.width())
+        .map(|line| textwrap::core::display_width(line))
         .max()
         .unwrap_or(0)
 }

--- a/src/utils/formatting/content_format.rs
+++ b/src/utils/formatting/content_format.rs
@@ -1,6 +1,5 @@
 #[cfg(feature = "tty")]
 use crossterm::style::{style, Stylize};
-use unicode_width::UnicodeWidthStr;
 
 use super::content_split::split_line;
 use crate::cell::Cell;
@@ -87,7 +86,7 @@ pub fn format_row(
         // Iterate over each line and split it into multiple lines, if necessary.
         // Newlines added by the user will be preserved.
         for line in cell.content.iter() {
-            if line.width() > info.content_width.into() {
+            if textwrap::core::display_width(line) > info.content_width.into() {
                 let mut splitted = split_line(line, info, delimiter);
                 cell_lines.append(&mut splitted);
             } else {
@@ -110,9 +109,9 @@ pub fn format_row(
                 let width: usize = info.content_width.into();
                 if width >= 6 {
                     // Truncate the line if '...' doesn't fit
-                    if last_line.width() >= width - 3 {
-                        let surplus = (last_line.width() + 3) - width;
-                        last_line.truncate(last_line.width() - surplus);
+                    if textwrap::core::display_width(last_line) >= width - 3 {
+                        let surplus = (textwrap::core::display_width(last_line) + 3) - width;
+                        last_line.truncate(textwrap::core::display_width(last_line) - surplus);
                     }
                     last_line.push_str("...");
                 }
@@ -177,7 +176,8 @@ pub fn format_row(
 #[allow(unused_variables)]
 fn align_line(table: &Table, info: &ColumnDisplayInfo, cell: &Cell, mut line: String) -> String {
     let content_width = info.content_width;
-    let remaining: usize = usize::from(content_width).saturating_sub(line.width());
+    let remaining: usize =
+        usize::from(content_width).saturating_sub(textwrap::core::display_width(&line));
 
     // Apply the styling before aligning the line, if the user requests it.
     // That way non-delimiter whitespaces won't have stuff like underlines.

--- a/src/utils/formatting/content_split.rs
+++ b/src/utils/formatting/content_split.rs
@@ -1,4 +1,4 @@
-use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
+use unicode_width::UnicodeWidthChar;
 
 use crate::utils::ColumnDisplayInfo;
 
@@ -28,8 +28,8 @@ pub fn split_line(line: &str, info: &ColumnDisplayInfo, delimiter: char) -> Vec<
 
     let mut current_line = String::new();
     while let Some(next) = elements.pop() {
-        let current_length = current_line.width();
-        let next_length = next.width();
+        let current_length = textwrap::core::display_width(&current_line);
+        let next_length = textwrap::core::display_width(&next);
 
         // Some helper variables
         // The length of the current line when combining it with the next element
@@ -39,7 +39,7 @@ pub fn split_line(line: &str, info: &ColumnDisplayInfo, delimiter: char) -> Vec<
             added_length += 1;
         }
         // The remaining width for this column. If we are on a non-empty line, subtract 1 for the delimiter.
-        let mut remaining_width = content_width - current_line.width();
+        let mut remaining_width = content_width - textwrap::core::display_width(&current_line);
         if !current_line.is_empty() {
             remaining_width = remaining_width.saturating_sub(1);
         }
@@ -148,7 +148,7 @@ const MIN_FREE_CHARS: usize = 2;
 /// Otherwise, we simply return the current line and basically don't do anything.
 fn check_if_full(lines: &mut Vec<String>, content_width: usize, current_line: String) -> String {
     // Already complete the current line, if there isn't space for more than two chars
-    if current_line.width() > content_width.saturating_sub(MIN_FREE_CHARS) {
+    if textwrap::core::display_width(&current_line) > content_width.saturating_sub(MIN_FREE_CHARS) {
         lines.push(current_line);
         return String::new();
     }


### PR DESCRIPTION
I wanted to use `comfy-table` with cells that contain ANSI escape characters, generated with the `colored` crate. However, when calculating the width of a cell, the ANSI escape characters were counted as well, resulting in funny looking tables.

By using textwrap's function to calculate the display width of a String, the tables have the correct cells and display correctly.