### PR TITLE
New preset, `UTF8_FULL_CONDENSED`

### DIFF
--- a/src/style/presets.rs
+++ b/src/style/presets.rs
@@ -84,6 +84,18 @@ pub const ASCII_MARKDOWN: &str = "||  |-|||           ";
 /// ```
 pub const UTF8_FULL: &str = "││──╞═╪╡┆╌┼├┤┬┴┌┐└┘";
 
+/// Default UTF8 style, but without spacing between rows.
+///
+/// ```text
+/// ┌───────┬───────┐
+/// │ Hello ┆ there │
+/// ╞═══════╪═══════╡
+/// │ a     ┆ b     │
+/// │ c     ┆ d     │
+/// └───────┴───────┘
+/// ```
+pub const UTF8_FULL_CONDENSED: &str = "││──╞═╪╡┆    ┬┴┌┐└┘";
+
 /// Default UTF8 style, but without any borders.
 ///
 /// ```text
@@ -95,7 +107,7 @@ pub const UTF8_FULL: &str = "││──╞═╪╡┆╌┼├┤┬┴┌┐
 /// ```
 pub const UTF8_NO_BORDERS: &str = "     ═╪ ┆╌┼        ";
 
-/// Just like the UTF8 FULL version, but without vertical/horizontal middle lines.
+/// Just like the UTF8_FULL style, but without vertical/horizontal middle lines.
 ///
 /// ```text
 /// ┌───────────────┐

--- a/tests/all/presets_test.rs
+++ b/tests/all/presets_test.rs
@@ -127,6 +127,22 @@ fn test_utf8_full() {
 }
 
 #[test]
+fn test_utf8_condensed() {
+    let mut table = get_preset_table();
+    table.load_preset(UTF8_FULL_CONDENSED);
+    println!("{table}");
+    let expected = "
+┌───────┬───────┐
+│ Hello ┆ there │
+╞═══════╪═══════╡
+│ a     ┆ b     │
+│ c     ┆ d     │
+└───────┴───────┘";
+    println!("{expected}");
+    assert_eq!("\n".to_string() + &table.trim_fmt(), expected);
+}
+
+#[test]
 fn test_utf8_no_borders() {
     let mut table = get_preset_table();
     table.load_preset(UTF8_NO_BORDERS);


### PR DESCRIPTION
Hopefully space for a new preset? :)

All the nice characteristics of `UTF8_FULL`, but without spacing between rows:

```python
# UTF_FULL:            UTF_FULL_CONDENSED:
# ┌───────┬───────┐    ┌───────┬───────┐
# │ Hello ┆ there │    │ Hello ┆ there │
# ╞═══════╪═══════╡    ╞═══════╪═══════╡
# │ a     ┆ b     │    │ a     ┆ b     │
# ├╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌┤    │ c     ┆ d     │
# │ c     ┆ d     │    │ e     ┆ f     │
# ├╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌┤    └───────┴───────┘
# │ e     ┆ f     │ 
# └───────┴───────┘    
```
Thanks!