### PR TITLE
New preset "ASCII_FULL_CONDENSED"

### DIFF
--- a/src/style/presets.rs
+++ b/src/style/presets.rs
@@ -11,7 +11,18 @@
 /// ```
 pub const ASCII_FULL: &str = "||--+==+|-+||++++++";
 
-/// Default style without any borders.
+/// Just like ASCII_FULL, but without dividers between rows.
+///
+/// ```text
+/// +-------+-------+
+/// | Hello | there |
+/// +===============+
+/// | a     | b     |
+/// | c     | d     |
+/// +-------+-------+
+pub const ASCII_FULL_CONDENSED: &str = "||--+==+|    ++++++";
+
+/// Just like ASCII_FULL, but without any borders.
 ///
 /// ```text
 ///  Hello | there
@@ -84,7 +95,7 @@ pub const ASCII_MARKDOWN: &str = "||  |-|||           ";
 /// ```
 pub const UTF8_FULL: &str = "││──╞═╪╡┆╌┼├┤┬┴┌┐└┘";
 
-/// Default UTF8 style, but without spacing between rows.
+/// Default UTF8 style, but without dividers between rows.
 ///
 /// ```text
 /// ┌───────┬───────┐

--- a/src/utils/arrangement/mod.rs
+++ b/src/utils/arrangement/mod.rs
@@ -42,7 +42,7 @@ pub fn arrange_content(table: &Table) -> Vec<ColumnDisplayInfo> {
         table_width
     } else {
         disabled::arrange(table, &mut infos, visible_columns, &max_content_widths);
-        return infos.into_iter().map(|(_, info)| info).collect();
+        return infos.into_values().collect();
     };
 
     match &table.arrangement {
@@ -54,7 +54,7 @@ pub fn arrange_content(table: &Table) -> Vec<ColumnDisplayInfo> {
         }
     }
 
-    infos.into_iter().map(|(_, info)| info).collect()
+    infos.into_values().collect()
 }
 
 #[cfg(test)]

--- a/tests/all/presets_test.rs
+++ b/tests/all/presets_test.rs
@@ -31,6 +31,22 @@ fn test_ascii_full() {
 }
 
 #[test]
+fn test_ascii_full_condensed() {
+    let mut table = get_preset_table();
+    table.load_preset(ASCII_FULL_CONDENSED);
+    println!("{table}");
+    let expected = "
++-------+-------+
+| Hello | there |
++===============+
+| a     | b     |
+| c     | d     |
++-------+-------+";
+    println!("{expected}");
+    assert_eq!("\n".to_string() + &table.trim_fmt(), expected);
+}
+
+#[test]
 fn test_ascii_no_borders() {
     let mut table = get_preset_table();
     table.load_preset(ASCII_NO_BORDERS);
@@ -127,7 +143,7 @@ fn test_utf8_full() {
 }
 
 #[test]
-fn test_utf8_condensed() {
+fn test_utf8_full_condensed() {
     let mut table = get_preset_table();
     table.load_preset(UTF8_FULL_CONDENSED);
     println!("{table}");


### PR DESCRIPTION
**New preset**:
I really should have submitted this alongside the preset added in #94 ... 😅 

Here's the ASCII equivalent of the previously introduced `UTF8_FULL_CONDENSED`; as before, it matches its corresponding `FULL` variant, just without the row dividers:

```python
# ASCII_FULL:          ASCII_FULL_CONDENSED:
# +-------+-------+    +-------+-------+
# | Hello | there |    | Hello | there |
# +===============+    +===============+
# | a     | b     |    | a     | b     |
# |-------+-------|    | c     | d     |
# | c     | d     |    | e     | f     |
# |-------+-------|    +-------+-------+
# | e     | f     |
# +-------+-------+
```

**Also**:
Fixed two lines in `utils/arrangement/mod.rs` that triggered the new `iter_kv_map` [clippy lint](https://github.com/rust-lang/rust-clippy/pull/9409):
```rust
// before
infos.into_iter().map(|(_, info)| info).collect()

// after
infos.into_values().collect()
```

Thanks!