### PR TITLE
Remove `doc-comment` in favor of crate level doc attribute.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,6 @@ unicode-width = "0.1"
 
 [dev-dependencies]
 criterion = "0.4"
-doc-comment = "0.3"
 pretty_assertions = "1"
 proptest = "1"
 rand = "0.8"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,6 @@
 #![forbid(unsafe_code)]
+#![cfg_attr(doctest, doc = include_str!("../README.md"))]
+
 mod cell;
 mod column;
 mod row;
@@ -17,6 +19,3 @@ pub use crate::column::Column;
 pub use crate::row::Row;
 pub use crate::table::{ColumnCellIter, Table};
 pub use style::*;
-
-#[cfg(doctest)]
-doc_comment::doctest!("../README.md");


### PR DESCRIPTION
This a well-polished project! While digging around in the source I was a bit confused why you used `doc_comment::doctest!()`.  A good solution I've found for including code snippets from `README`s in cargo tests is by using the [crate level `#[doc]` attribute](https://doc.rust-lang.org/rustdoc/write-documentation/the-doc-attribute.html) and `#[cfg_attr]`.

In practice, both these approaches have the same result. This method is slightly faster and doesn't require developers to pull in another dependency for tests 👍🏽.

If you want proof, take a look at the outputs of `cargo test` before and after I made these changes. They both ignore the snippets on lines 218 and 234 while correctly running the tests on lines 43 and 82.

[newtest.md](https://github.com/Nukesor/comfy-table/files/10885517/newtest.md)
[oldtest.md](https://github.com/Nukesor/comfy-table/files/10885518/oldtest.md)

If this wasn't your intended use of `doc_comment::doctest!()`, I'd love to know what it's for.

Thanks!