### PR TITLE
Add 'add_row_if' and 'add_rows_if' methods

### DIFF
--- a/src/table.rs
+++ b/src/table.rs
@@ -143,14 +143,14 @@ impl Table {
     ///
     /// let mut table = Table::new();
     /// let row = Row::from(vec!["One", "Two"]);
-    /// table.add_row_if(|index, rows| true, row);
+    /// table.add_row_if(|index, row| true, row);
     /// ```
     pub fn add_row_if<P, T>(&mut self, predicate: P, row: T) -> &mut Self
     where
-        P: Fn(usize, &Vec<Row>) -> bool,
+        P: Fn(usize, &T) -> bool,
         T: Into<Row>,
     {
-        if predicate(self.rows.len(), &self.rows) {
+        if predicate(self.rows.len(), &row) {
             return self.add_row(row);
         }
 
@@ -198,11 +198,11 @@ impl Table {
     /// ```
     pub fn add_rows_if<P, I>(&mut self, predicate: P, rows: I) -> &mut Self
     where
-        P: Fn(usize, &Vec<Row>) -> bool,
+        P: Fn(usize, &I) -> bool,
         I: IntoIterator,
         I::Item: Into<Row>,
     {
-        if predicate(self.rows.len(), &self.rows) {
+        if predicate(self.rows.len(), &rows) {
             return self.add_rows(rows);
         }
 

--- a/src/table.rs
+++ b/src/table.rs
@@ -143,14 +143,14 @@ impl Table {
     ///
     /// let mut table = Table::new();
     /// let row = Row::from(vec!["One", "Two"]);
-    /// table.add_row_if(|| true, row);
+    /// table.add_row_if(|index, rows| true, row);
     /// ```
     pub fn add_row_if<P, T>(&mut self, predicate: P, row: T) -> &mut Self
     where
-        P: Fn() -> bool,
+        P: Fn(usize, &Vec<Row>) -> bool,
         T: Into<Row>,
     {
-        if predicate() {
+        if predicate(self.rows.len(), &self.rows) {
             return self.add_row(row);
         }
 
@@ -194,15 +194,15 @@ impl Table {
     ///     Row::from(vec!["One", "Two"]),
     ///     Row::from(vec!["Three", "Four"])
     /// ];
-    /// table.add_rows_if(|| true, rows);
+    /// table.add_rows_if(|index, rows| true, rows);
     /// ```
     pub fn add_rows_if<P, I>(&mut self, predicate: P, rows: I) -> &mut Self
     where
-        P: Fn() -> bool,
+        P: Fn(usize, &Vec<Row>) -> bool,
         I: IntoIterator,
         I::Item: Into<Row>,
     {
-        if predicate() {
+        if predicate(self.rows.len(), &self.rows) {
             return self.add_rows(rows);
         }
 

--- a/src/table.rs
+++ b/src/table.rs
@@ -136,6 +136,27 @@ impl Table {
         self
     }
 
+    /// Add a new row to the table if the predicate evaluates to `true`.
+    ///
+    /// ```
+    /// use comfy_table::{Table, Row};
+    ///
+    /// let mut table = Table::new();
+    /// let row = Row::from(vec!["One", "Two"]);
+    /// table.add_row_if(|| true, row);
+    /// ```
+    pub fn add_row_if<P, T>(&mut self, predicate: P, row: T) -> &mut Self
+    where
+        P: Fn() -> bool,
+        T: Into<Row>,
+    {
+        if predicate() {
+            return self.add_row(row);
+        }
+
+        self
+    }
+
     /// Add multiple rows to the table.
     ///
     /// ```
@@ -158,6 +179,31 @@ impl Table {
             self.autogenerate_columns(&row);
             row.index = Some(self.rows.len());
             self.rows.push(row);
+        }
+
+        self
+    }
+
+    /// Add multiple rows to the table if the predicate evaluates to `true`.
+    ///
+    /// ```
+    /// use comfy_table::{Table, Row};
+    ///
+    /// let mut table = Table::new();
+    /// let rows = vec![
+    ///     Row::from(vec!["One", "Two"]),
+    ///     Row::from(vec!["Three", "Four"])
+    /// ];
+    /// table.add_rows_if(|| true, rows);
+    /// ```
+    pub fn add_rows_if<P, I>(&mut self, predicate: P, rows: I) -> &mut Self
+    where
+        P: Fn() -> bool,
+        I: IntoIterator,
+        I::Item: Into<Row>,
+    {
+        if predicate() {
+            return self.add_rows(rows);
         }
 
         self

--- a/tests/all/add_predicate.rs
+++ b/tests/all/add_predicate.rs
@@ -3,7 +3,7 @@ use pretty_assertions::assert_eq;
 use comfy_table::*;
 
 #[test]
-fn add_predicate_true() {
+fn add_predicate_single_true() {
     let mut table = Table::new();
     table
         .set_header(&vec!["Header1", "Header2", "Header3"])
@@ -36,7 +36,7 @@ fn add_predicate_true() {
 }
 
 #[test]
-fn add_predicate_false() {
+fn add_predicate_single_false() {
     let mut table = Table::new();
     table
         .set_header(&vec!["Header1", "Header2", "Header3"])
@@ -65,7 +65,7 @@ fn add_predicate_false() {
 }
 
 #[test]
-fn add_predicate_mixed() {
+fn add_predicate_single_mixed() {
     let mut table = Table::new();
     table
         .set_header(&vec!["Header1", "Header2", "Header3"])
@@ -85,6 +85,111 @@ fn add_predicate_mixed() {
                 "Now\nadd some\nmulti line stuff",
                 "This is awesome",
             ],
+        );
+
+    println!("{table}");
+    let expected = "
++----------------------+----------------------+------------------------+
+| Header1              | Header2              | Header3                |
++======================================================================+
+| This is a text       | This is another text | This is the third text |
+|----------------------+----------------------+------------------------|
+| This is another text | Now                  | This is awesome        |
+|                      | add some             |                        |
+|                      | multi line stuff     |                        |
++----------------------+----------------------+------------------------+";
+    assert_eq!("\n".to_string() + &table.to_string(), expected);
+}
+
+#[test]
+fn add_predicate_multi_true() {
+    let mut table = Table::new();
+    let rows = vec![
+        Row::from(&vec![
+            "This is a text",
+            "This is another text",
+            "This is the third text",
+        ]),
+        Row::from(&vec![
+            "This is another text",
+            "Now\nadd some\nmulti line stuff",
+            "This is awesome",
+        ]),
+    ];
+
+    table
+        .set_header(&vec!["Header1", "Header2", "Header3"])
+        .add_rows_if(|| true, rows);
+
+    println!("{table}");
+    let expected = "
++----------------------+----------------------+------------------------+
+| Header1              | Header2              | Header3                |
++======================================================================+
+| This is a text       | This is another text | This is the third text |
+|----------------------+----------------------+------------------------|
+| This is another text | Now                  | This is awesome        |
+|                      | add some             |                        |
+|                      | multi line stuff     |                        |
++----------------------+----------------------+------------------------+";
+    assert_eq!("\n".to_string() + &table.to_string(), expected);
+}
+
+#[test]
+fn add_predicate_multi_false() {
+    let mut table = Table::new();
+    table
+        .set_header(&vec!["Header1", "Header2", "Header3"])
+        .add_row(&vec![
+            "This is a text",
+            "This is another text",
+            "This is the third text",
+        ])
+        .add_rows_if(
+            || false,
+            vec![Row::from(&vec![
+                "This is another text",
+                "Now\nadd some\nmulti line stuff",
+                "This is awesome",
+            ])],
+        );
+
+    println!("{table}");
+    let expected = "
++----------------+----------------------+------------------------+
+| Header1        | Header2              | Header3                |
++================================================================+
+| This is a text | This is another text | This is the third text |
++----------------+----------------------+------------------------+";
+    assert_eq!("\n".to_string() + &table.to_string(), expected);
+}
+
+#[test]
+fn add_predicate_multi_mixed() {
+    let mut table = Table::new();
+    let rows = vec![
+        Row::from(&vec![
+            "This is a text",
+            "This is another text",
+            "This is the third text",
+        ]),
+        Row::from(&vec![
+            "This is another text",
+            "Now\nadd some\nmulti line stuff",
+            "This is awesome",
+        ]),
+    ];
+
+    table
+        .set_header(&vec!["Header1", "Header2", "Header3"])
+        .add_rows_if(|| true, rows)
+        .add_rows_if(
+            || false,
+            vec![Row::from(&vec![
+                "I won't get displayed",
+                "Me neither",
+                "Same here!",
+            ])],
         );
 
     println!("{table}");

--- a/tests/all/add_predicate.rs
+++ b/tests/all/add_predicate.rs
@@ -13,7 +13,7 @@ fn add_predicate_single_true() {
             "This is the third text",
         ])
         .add_row_if(
-            || true,
+            |_, _| true,
             &vec![
                 "This is another text",
                 "Now\nadd some\nmulti line stuff",
@@ -46,7 +46,7 @@ fn add_predicate_single_false() {
             "This is the third text",
         ])
         .add_row_if(
-            || false,
+            |_, _| false,
             &vec![
                 "This is another text",
                 "Now\nadd some\nmulti line stuff",
@@ -75,11 +75,11 @@ fn add_predicate_single_mixed() {
             "This is the third text",
         ])
         .add_row_if(
-            || false,
+            |_, _| false,
             &vec!["I won't get displayed", "Me neither", "Same here!"],
         )
         .add_row_if(
-            || true,
+            |_, _| true,
             &vec![
                 "This is another text",
                 "Now\nadd some\nmulti line stuff",
@@ -119,7 +119,7 @@ fn add_predicate_multi_true() {
 
     table
         .set_header(&vec!["Header1", "Header2", "Header3"])
-        .add_rows_if(|| true, rows);
+        .add_rows_if(|_, _| true, rows);
 
     println!("{table}");
     let expected = "
@@ -146,7 +146,7 @@ fn add_predicate_multi_false() {
             "This is the third text",
         ])
         .add_rows_if(
-            || false,
+            |_, _| false,
             vec![Row::from(&vec![
                 "This is another text",
                 "Now\nadd some\nmulti line stuff",
@@ -182,9 +182,9 @@ fn add_predicate_multi_mixed() {
 
     table
         .set_header(&vec!["Header1", "Header2", "Header3"])
-        .add_rows_if(|| true, rows)
+        .add_rows_if(|_, _| true, rows)
         .add_rows_if(
-            || false,
+            |_, _| false,
             vec![Row::from(&vec![
                 "I won't get displayed",
                 "Me neither",

--- a/tests/all/add_predicate.rs
+++ b/tests/all/add_predicate.rs
@@ -102,6 +102,35 @@ fn add_predicate_single_mixed() {
 }
 
 #[test]
+fn add_predicate_single_wrong_row_count() {
+    let mut table = Table::new();
+    table
+        .set_header(&vec!["Header1", "Header2", "Header3"])
+        .add_row(&vec![
+            "This is a text",
+            "This is another text",
+            "This is the third text",
+        ])
+        .add_row_if(
+            |_, row| row.len() == 2,
+            &vec![
+                "This is another text",
+                "Now\nadd some\nmulti line stuff",
+                "This is awesome",
+            ],
+        );
+
+    println!("{table}");
+    let expected = "
++----------------+----------------------+------------------------+
+| Header1        | Header2              | Header3                |
++================================================================+
+| This is a text | This is another text | This is the third text |
++----------------+----------------------+------------------------+";
+    assert_eq!("\n".to_string() + &table.to_string(), expected);
+}
+
+#[test]
 fn add_predicate_multi_true() {
     let mut table = Table::new();
     let rows = vec![
@@ -203,5 +232,34 @@ fn add_predicate_multi_mixed() {
 |                      | add some             |                        |
 |                      | multi line stuff     |                        |
 +----------------------+----------------------+------------------------+";
+    assert_eq!("\n".to_string() + &table.to_string(), expected);
+}
+
+#[test]
+fn add_predicate_multi_wrong_rows_count() {
+    let mut table = Table::new();
+    table
+        .set_header(&vec!["Header1", "Header2", "Header3"])
+        .add_row(&vec![
+            "This is a text",
+            "This is another text",
+            "This is the third text",
+        ])
+        .add_rows_if(
+            |_, rows| rows.len() == 2,
+            vec![Row::from(&vec![
+                "This is another text",
+                "Now\nadd some\nmulti line stuff",
+                "This is awesome",
+            ])],
+        );
+
+    println!("{table}");
+    let expected = "
++----------------+----------------------+------------------------+
+| Header1        | Header2              | Header3                |
++================================================================+
+| This is a text | This is another text | This is the third text |
++----------------+----------------------+------------------------+";
     assert_eq!("\n".to_string() + &table.to_string(), expected);
 }

--- a/tests/all/add_predicate.rs
+++ b/tests/all/add_predicate.rs
@@ -1,0 +1,102 @@
+use pretty_assertions::assert_eq;
+
+use comfy_table::*;
+
+#[test]
+fn add_predicate_true() {
+    let mut table = Table::new();
+    table
+        .set_header(&vec!["Header1", "Header2", "Header3"])
+        .add_row(&vec![
+            "This is a text",
+            "This is another text",
+            "This is the third text",
+        ])
+        .add_row_if(
+            || true,
+            &vec![
+                "This is another text",
+                "Now\nadd some\nmulti line stuff",
+                "This is awesome",
+            ],
+        );
+
+    println!("{table}");
+    let expected = "
++----------------------+----------------------+------------------------+
+| Header1              | Header2              | Header3                |
++======================================================================+
+| This is a text       | This is another text | This is the third text |
+|----------------------+----------------------+------------------------|
+| This is another text | Now                  | This is awesome        |
+|                      | add some             |                        |
+|                      | multi line stuff     |                        |
++----------------------+----------------------+------------------------+";
+    assert_eq!("\n".to_string() + &table.to_string(), expected);
+}
+
+#[test]
+fn add_predicate_false() {
+    let mut table = Table::new();
+    table
+        .set_header(&vec!["Header1", "Header2", "Header3"])
+        .add_row(&vec![
+            "This is a text",
+            "This is another text",
+            "This is the third text",
+        ])
+        .add_row_if(
+            || false,
+            &vec![
+                "This is another text",
+                "Now\nadd some\nmulti line stuff",
+                "This is awesome",
+            ],
+        );
+
+    println!("{table}");
+    let expected = "
++----------------+----------------------+------------------------+
+| Header1        | Header2              | Header3                |
++================================================================+
+| This is a text | This is another text | This is the third text |
++----------------+----------------------+------------------------+";
+    assert_eq!("\n".to_string() + &table.to_string(), expected);
+}
+
+#[test]
+fn add_predicate_mixed() {
+    let mut table = Table::new();
+    table
+        .set_header(&vec!["Header1", "Header2", "Header3"])
+        .add_row(&vec![
+            "This is a text",
+            "This is another text",
+            "This is the third text",
+        ])
+        .add_row_if(
+            || false,
+            &vec!["I won't get displayed", "Me neither", "Same here!"],
+        )
+        .add_row_if(
+            || true,
+            &vec![
+                "This is another text",
+                "Now\nadd some\nmulti line stuff",
+                "This is awesome",
+            ],
+        );
+
+    println!("{table}");
+    let expected = "
++----------------------+----------------------+------------------------+
+| Header1              | Header2              | Header3                |
++======================================================================+
+| This is a text       | This is another text | This is the third text |
+|----------------------+----------------------+------------------------|
+| This is another text | Now                  | This is awesome        |
+|                      | add some             |                        |
+|                      | multi line stuff     |                        |
++----------------------+----------------------+------------------------+";
+    assert_eq!("\n".to_string() + &table.to_string(), expected);
+}

--- a/tests/all/mod.rs
+++ b/tests/all/mod.rs
@@ -17,6 +17,8 @@ mod simple_test;
 mod styling_test;
 mod utf_8_characters;
 
+mod add_predicate;
+
 pub fn assert_table_line_width(table: &Table, count: usize) {
     for line in table.lines() {
         assert_eq!(line.width(), count);

--- a/tests/all/mod.rs
+++ b/tests/all/mod.rs
@@ -1,6 +1,7 @@
 use comfy_table::Table;
 use unicode_width::UnicodeWidthStr;
 
+mod add_predicate;
 mod alignment_test;
 #[cfg(feature = "tty")]
 mod combined_test;
@@ -16,8 +17,6 @@ mod simple_test;
 #[cfg(feature = "tty")]
 mod styling_test;
 mod utf_8_characters;
-
-mod add_predicate;
 
 pub fn assert_table_line_width(table: &Table, count: usize) {
     for line in table.lines() {


### PR DESCRIPTION
This PR adds the ability to only add (a) row(s) when the specified predicate evaluates to `true`. This enables a smoother "flow" when building tables. For example:

```rust
let mut table = Table::new();
table
    .set_header(&vec!["Header1", "Header2", "Header3"])
    .add_row(&vec![
        "This is a text",
        "This is another text",
        "This is the third text",
    ]);
if predicate {
    table.add_row(vec!["", "", ""]);
}
table
    .add_row(vec!["", "", ""])
    .add_row(vec!["", "", ""]);
```

With the changes introduced by this PR, we could write the above code like:

```rust
let mut table = Table::new();
table
    .set_header(&vec!["Header1", "Header2", "Header3"])
    .add_row(&vec![
        "This is a text",
        "This is another text",
        "This is the third text",
    ]);
    .add_row_if(|| predicate, vec!["", "", ""])
    .add_row(vec!["", "", ""])
    .add_row(vec!["", "", ""]);
```

The same feature is implemented for `add_rows_if`. I also added some tests, which should cover the newly added feature.