### PR TITLE
feat: Add col_count, row_count and is_empty methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Added
 
 - Add helper methods `(col,row)_count` and `is_empty`. The first set of methods return the number of columns and rows
-  respectively. The method `is_empty` returns if the table is empty (contains no data rows).
+  respectively. The method `is_empty` returns if the table is empty (contains no data rows). Implemented by
+  [Techassi](https://github.com/Techassi) in [#106](https://github.com/Nukesor/comfy-table/pull/119).
 
 ## [7.0.1] - 2023-06-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - Add helper methods `(col,row)_count` and `is_empty`. The first set of methods return the number of columns and rows
   respectively. The method `is_empty` returns if the table is empty (contains no data rows). Implemented by
-  [Techassi](https://github.com/Techassi) in [#106](https://github.com/Nukesor/comfy-table/pull/119).
+  [Techassi](https://github.com/Techassi) in [#119](https://github.com/Nukesor/comfy-table/pull/119).
 
 ## [7.0.1] - 2023-06-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Added
+
+- Add helper methods `(col,row)_count` and `is_empty`. The first set of methods return the number of columns and rows
+  respectively. The method `is_empty` returns if the table is empty (contains no data rows).
+
 ## [7.0.1] - 2023-06-16
 
 ## Fix

--- a/src/table.rs
+++ b/src/table.rs
@@ -126,7 +126,7 @@ impl Table {
     /// let mut table = Table::new();
     /// table.set_header(vec!["Col 1", "Col 2", "Col 3"]);
     ///
-    /// assert_eq!(table.col_count(), 3);
+    /// assert_eq!(table.column_count(), 3);
     /// ```
     pub fn column_count(&mut self) -> usize {
         self.discover_columns();

--- a/src/table.rs
+++ b/src/table.rs
@@ -128,7 +128,8 @@ impl Table {
     ///
     /// assert_eq!(table.col_count(), 3);
     /// ```
-    pub fn col_count(&self) -> usize {
+    pub fn column_count(&mut self) -> usize {
+        self.discover_columns();
         self.columns.len()
     }
 

--- a/src/table.rs
+++ b/src/table.rs
@@ -118,6 +118,20 @@ impl Table {
         self.header.as_ref()
     }
 
+    /// Returns the number of currently present columns.
+    ///
+    /// ```
+    /// use comfy_table::Table;
+    ///
+    /// let mut table = Table::new();
+    /// table.set_header(vec!["Col 1", "Col 2", "Col 3"]);
+    ///
+    /// assert_eq!(table.col_count(), 3);
+    /// ```
+    pub fn col_count(&self) -> usize {
+        self.columns.len()
+    }
+
     /// Add a new row to the table.
     ///
     /// ```
@@ -207,6 +221,35 @@ impl Table {
         }
 
         self
+    }
+
+    /// Returns the number of currently present rows.
+    ///
+    /// ```
+    /// use comfy_table::Table;
+    ///
+    /// let mut table = Table::new();
+    /// table.add_row(vec!["One", "Two"]);
+    ///
+    /// assert_eq!(table.row_count(), 1);
+    /// ```
+    pub fn row_count(&self) -> usize {
+        self.rows.len()
+    }
+
+    /// Returns if the table is empty (contains no data rows).
+    ///
+    /// ```
+    /// use comfy_table::Table;
+    ///
+    /// let mut table = Table::new();
+    /// assert!(table.is_empty());
+    ///
+    /// table.add_row(vec!["One", "Two"]);
+    /// assert!(!table.is_empty());
+    /// ```
+    pub fn is_empty(&self) -> bool {
+        self.rows.is_empty()
     }
 
     /// Enforce a max width that should be used in combination with [dynamic content arrangement](ContentArrangement::Dynamic).\

--- a/tests/all/counts.rs
+++ b/tests/all/counts.rs
@@ -7,13 +7,13 @@ fn test_col_count_header() {
     let mut table = Table::new();
 
     table.set_header(vec!["Col 1", "Col 2", "Col 3"]);
-    assert_eq!(table.col_count(), 3);
+    assert_eq!(table.column_count(), 3);
 
     table.set_header(vec!["Col 1", "Col 2", "Col 3", "Col 4"]);
-    assert_eq!(table.col_count(), 4);
+    assert_eq!(table.column_count(), 4);
 
     table.set_header(vec!["Col I", "Col II"]);
-    assert_eq!(table.col_count(), 4);
+    assert_eq!(table.column_count(), 4);
 }
 
 #[test]
@@ -21,10 +21,10 @@ fn test_col_count_row() {
     let mut table = Table::new();
 
     table.add_row(vec!["Foo", "Bar"]);
-    assert_eq!(table.col_count(), 2);
+    assert_eq!(table.column_count(), 2);
 
     table.add_row(vec!["Bar", "Foo", "Baz"]);
-    assert_eq!(table.col_count(), 3);
+    assert_eq!(table.column_count(), 3);
 }
 
 #[test]

--- a/tests/all/counts.rs
+++ b/tests/all/counts.rs
@@ -1,0 +1,55 @@
+use pretty_assertions::assert_eq;
+
+use comfy_table::*;
+
+#[test]
+fn test_col_count_header() {
+    let mut table = Table::new();
+
+    table.set_header(vec!["Col 1", "Col 2", "Col 3"]);
+    assert_eq!(table.col_count(), 3);
+
+    table.set_header(vec!["Col 1", "Col 2", "Col 3", "Col 4"]);
+    assert_eq!(table.col_count(), 4);
+
+    table.set_header(vec!["Col I", "Col II"]);
+    assert_eq!(table.col_count(), 4);
+}
+
+#[test]
+fn test_col_count_row() {
+    let mut table = Table::new();
+
+    table.add_row(vec!["Foo", "Bar"]);
+    assert_eq!(table.col_count(), 2);
+
+    table.add_row(vec!["Bar", "Foo", "Baz"]);
+    assert_eq!(table.col_count(), 3);
+}
+
+#[test]
+fn test_row_count() {
+    let mut table = Table::new();
+    assert_eq!(table.row_count(), 0);
+
+    table.add_row(vec!["Foo", "Bar"]);
+    assert_eq!(table.row_count(), 1);
+
+    table.add_row(vec!["Bar", "Foo", "Baz"]);
+    assert_eq!(table.row_count(), 2);
+
+    table.add_row_if(|_, _| false, vec!["Baz", "Bar", "Foo"]);
+    assert_eq!(table.row_count(), 2);
+
+    table.add_row_if(|_, _| true, vec!["Foo", "Baz", "Bar"]);
+    assert_eq!(table.row_count(), 3);
+}
+
+#[test]
+fn test_is_empty() {
+    let mut table = Table::new();
+    assert_eq!(table.is_empty(), true);
+
+    table.add_row(vec!["Foo", "Bar"]);
+    assert_eq!(table.is_empty(), false);
+}

--- a/tests/all/mod.rs
+++ b/tests/all/mod.rs
@@ -7,6 +7,7 @@ mod alignment_test;
 mod combined_test;
 mod constraints_test;
 mod content_arrangement_test;
+mod counts;
 mod custom_delimiter_test;
 mod edge_cases;
 mod hidden_test;


### PR DESCRIPTION
This PR adds three methods:

- `column_count`: Returns the number of columns in the table
- `row_count`: Returns the number of rows in the table
- `is_empty`: Returns if the table is empty (contains no data rows)