### PR TITLE
feat: add Table.remove_header()

### DIFF
--- a/src/table.rs
+++ b/src/table.rs
@@ -118,6 +118,13 @@ impl Table {
         self.header.as_ref()
     }
 
+    /// Remove the header.
+    pub fn remove_header(&mut self) -> &mut Self {
+        self.header = None;
+
+        self
+    }
+
     /// Add a new row to the table.
     ///
     /// ```


### PR DESCRIPTION
About the motivation: to be able to modify a table created elsewhere. The `Clone` implementation might be helpful too, but it's orthogonal to this patch.