### PR TITLE
feat: Add column helper methods

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,7 +28,7 @@ jobs:
           - x86_64-pc-windows-msvc
           - x86_64-apple-darwin
           - wasm32-wasi
-        toolchain: [stable, nightly, 1.64]
+        toolchain: [stable, nightly, 1.70]
         include:
           - target: x86_64-unknown-linux-gnu
             os: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Add helper methods `(col,row)_count` and `is_empty`. The first set of methods return the number of columns and rows
   respectively. The method `is_empty` returns if the table is empty (contains no data rows). Implemented by
   [Techassi](https://github.com/Techassi) in [#119](https://github.com/Nukesor/comfy-table/pull/119).
+- Add four new methods for dynamically adding new columns to the header: `add_column`, `add_column_if`, `add_columns`,
+  and `add_columns_if`. Implemented by [Techassi](https://github.com/Techassi) in [#CHANGEME]().
 
 ## [7.0.1] - 2023-06-16
 
@@ -18,7 +20,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - Fix a panic when working with extreme paddings, where `(padding.left + padding.right) > u16::MAX`.
 - Fix a panic when working with extremely long content, where `(content_width + padding) > u16::MAX`.
-- Properly enforce lower boundery constraints.
+- Properly enforce lower boundary constraints.
   Previously, "normal" columns were allocated before lower boundaries were respected.
   This could lead to scenarios, where the table would grow beyond the specified size, when there was a lower boundary.
 - Fix calculation of column widths for empty columns.

--- a/tests/all/simple_test.rs
+++ b/tests/all/simple_test.rs
@@ -122,3 +122,63 @@ fn add_column() {
 +---------+---------+-----------+----------+";
     assert_eq!(expected, "\n".to_string() + &table.to_string());
 }
+
+#[test]
+fn add_column_if() {
+    let mut table = Table::new();
+    table
+        .set_header(&vec!["Header1", "Header2", "Header3"])
+        .add_row(&vec!["One One", "One Two", "One Three"])
+        .add_column_if(|_, _| false, "Header4");
+
+    println!("{table}");
+    let expected = "
++---------+---------+-----------+
+| Header1 | Header2 | Header3   |
++===============================+
+| One One | One Two | One Three |
++---------+---------+-----------+";
+    assert_eq!(expected, "\n".to_string() + &table.to_string());
+}
+
+#[test]
+fn add_columns() {
+    let mut table = Table::new();
+    table
+        .set_header(&vec!["Header1", "Header2", "Header3"])
+        .add_row(&vec!["One One", "One Two", "One Three"])
+        .add_columns(vec!["Header4", "Header5"])
+        .add_row(&vec!["Two One", "Two Two", "Two Three", "Two Four"]);
+
+    println!("{table}");
+    let expected = "
++---------+---------+-----------+----------+---------+
+| Header1 | Header2 | Header3   | Header4  | Header5 |
++====================================================+
+| One One | One Two | One Three |          |         |
+|---------+---------+-----------+----------+---------|
+| Two One | Two Two | Two Three | Two Four |         |
++---------+---------+-----------+----------+---------+";
+    assert_eq!(expected, "\n".to_string() + &table.to_string());
+}
+
+#[test]
+fn add_columns_if() {
+    let mut table = Table::new();
+    table
+        .set_header(&vec!["Header1", "Header2", "Header3"])
+        .add_row(&vec!["One One", "One Two", "One Three"])
+        .add_columns_if(|index, _| index == 3, vec!["Header4", "Header5"])
+        .add_row(&vec!["Two One", "Two Two", "Two Three", "Two Four"]);
+
+    println!("{table}");
+    let expected = "
++---------+---------+-----------+----------+---------+
+| Header1 | Header2 | Header3   | Header4  | Header5 |
++====================================================+
+| One One | One Two | One Three |          |         |
+|---------+---------+-----------+----------+---------|
+| Two One | Two Two | Two Three | Two Four |         |
++---------+---------+-----------+----------+---------+";
+    assert_eq!(expected, "\n".to_string() + &table.to_string());
+}

--- a/tests/all/simple_test.rs
+++ b/tests/all/simple_test.rs
@@ -101,3 +101,24 @@ fn lines() {
 
     assert_eq!(actual.collect::<Vec<String>>(), expected);
 }
+
+#[test]
+fn add_column() {
+    let mut table = Table::new();
+    table
+        .set_header(&vec!["Header1", "Header2", "Header3"])
+        .add_row(&vec!["One One", "One Two", "One Three"])
+        .add_column("Header4")
+        .add_row(&vec!["Two One", "Two Two", "Two Three", "Two Four"]);
+
+    println!("{table}");
+    let expected = "
++---------+---------+-----------+----------+
+| Header1 | Header2 | Header3   | Header4  |
++==========================================+
+| One One | One Two | One Three |          |
+|---------+---------+-----------+----------|
+| Two One | Two Two | Two Three | Two Four |
++---------+---------+-----------+----------+";
+    assert_eq!(expected, "\n".to_string() + &table.to_string());
+}


### PR DESCRIPTION
This PR adds the following methods:

- `add_column`
- `add_column_if`
- `add_columns`
- `add_columns_if`

Their use is documented via doc comments.