### PR TITLE
build(deps): crossterm 0.28 windows

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,4 +71,4 @@ rstest = "0.23"
 [target.'cfg(not(windows))'.dependencies]
 crossterm = { version = "0.28", optional=true, default-features = false }
 [target.'cfg(windows)'.dependencies]
-crossterm = { version = "0.27", optional=true, default-features = false, features=["windows"] }
+crossterm = { version = "0.28", optional=true, default-features = false, features=["windows"] }


### PR DESCRIPTION
It looks like the merged dependabot PR for crosstable only updated the non-Windows version; the Windows version was left untouched. I wasn't able to tell if this was on purpose or not.