### PR TITLE
fix: multibyte line trucation

### DIFF
--- a/src/utils/formatting/content_format.rs
+++ b/src/utils/formatting/content_format.rs
@@ -4,6 +4,7 @@ use unicode_width::UnicodeWidthStr;
 
 use super::content_split::measure_text_width;
 use super::content_split::split_line;
+use super::content_split::split_long_word;
 
 use crate::cell::Cell;
 use crate::row::Row;
@@ -121,9 +122,11 @@ pub fn format_row(
                 let width: usize = info.content_width.into();
                 if width >= 6 {
                     // Truncate the line if '...' doesn't fit
-                    if last_line.width() >= width - 3 {
+                    if last_line.width() > width - 3 {
                         let surplus = (last_line.width() + 3) - width;
-                        last_line.truncate(last_line.width() - surplus);
+                        let split_result = split_long_word(last_line.width() - surplus, &last_line);
+                        last_line.clear();
+                        last_line.push_str(&split_result.0);
                     }
                     last_line.push_str("...");
                 }

--- a/tests/all/utf_8_characters.rs
+++ b/tests/all/utf_8_characters.rs
@@ -56,3 +56,25 @@ fn multi_character_utf8_word_splitting() {
     println!("{expected}");
     assert_eq!(expected, "\n".to_string() + &table.to_string());
 }
+
+#[test]
+fn multi_character_utf8_line_truncation() {
+    let mut table = Table::new();
+    let mut row = Row::new();
+    let test_string = "😀😃😄😁";
+    let row = row.max_height(1).add_cell(Cell::new(test_string));
+    table
+        .set_content_arrangement(ContentArrangement::Dynamic)
+        .set_header(vec!["test"])
+        .add_row(row.clone())
+        .set_width(10); // column content (6) + padding + border
+
+    let expected = "
++--------+
+| test   |
++========+
+| 😀...  |
++--------+";
+    println!("{expected}");
+    assert_eq!(expected, "\n".to_string() + &table.to_string());
+}


### PR DESCRIPTION
In some cases of cell content truncation (i.e. when the last line displayed has to be truncated to add ellipses), the library would throw an error if the content contained multi-byte characters
See the added test case and note that it previously failed