### PR TITLE
chore: reduce proc-macro dep strum

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,8 +55,6 @@ integration_test = []
 [dependencies]
 ansi-str = { version = "0.8", optional = true }
 console = { version = "0.15", optional = true }
-strum = "0.26"
-strum_macros = "0.26"
 unicode-width = "0.2"
 
 [dev-dependencies]

--- a/src/style/table.rs
+++ b/src/style/table.rs
@@ -68,7 +68,7 @@ pub enum TableComponent {
 }
 
 impl TableComponent {
-    pub fn components() -> impl Iterator<Item = TableComponent> {
+    const fn components() -> [TableComponent; 19] {
         [
             TableComponent::LeftBorder,
             TableComponent::RightBorder,
@@ -90,6 +90,9 @@ impl TableComponent {
             TableComponent::BottomLeftCorner,
             TableComponent::BottomRightCorner,
         ]
-        .into_iter()
+    }
+
+    pub fn iter() -> impl Iterator<Item = TableComponent> {
+        TableComponent::components().into_iter()
     }
 }

--- a/src/style/table.rs
+++ b/src/style/table.rs
@@ -1,5 +1,3 @@
-use strum_macros::EnumIter;
-
 /// Specify how comfy_table should arrange the content in your table.
 ///
 /// ```
@@ -46,7 +44,7 @@ pub enum ContentArrangement {
 /// |   |   |   |    The inner "+" chars are MiddleIntersections
 /// +---+---+---+
 /// ```
-#[derive(Debug, PartialEq, Eq, Hash, EnumIter, Clone, Copy)]
+#[derive(Debug, PartialEq, Eq, Hash, Clone, Copy)]
 pub enum TableComponent {
     LeftBorder,
     RightBorder,
@@ -67,4 +65,31 @@ pub enum TableComponent {
     TopRightCorner,
     BottomLeftCorner,
     BottomRightCorner,
+}
+
+impl TableComponent {
+    pub fn components() -> impl Iterator<Item = TableComponent> {
+        [
+            TableComponent::LeftBorder,
+            TableComponent::RightBorder,
+            TableComponent::TopBorder,
+            TableComponent::BottomBorder,
+            TableComponent::LeftHeaderIntersection,
+            TableComponent::HeaderLines,
+            TableComponent::MiddleHeaderIntersections,
+            TableComponent::RightHeaderIntersection,
+            TableComponent::VerticalLines,
+            TableComponent::HorizontalLines,
+            TableComponent::MiddleIntersections,
+            TableComponent::LeftBorderIntersections,
+            TableComponent::RightBorderIntersections,
+            TableComponent::TopBorderIntersections,
+            TableComponent::BottomBorderIntersections,
+            TableComponent::TopLeftCorner,
+            TableComponent::TopRightCorner,
+            TableComponent::BottomLeftCorner,
+            TableComponent::BottomRightCorner,
+        ]
+        .into_iter()
+    }
 }

--- a/src/table.rs
+++ b/src/table.rs
@@ -453,7 +453,7 @@ impl Table {
     ///
     /// If the string is too long, remaining charaacters will be simply ignored.
     pub fn load_preset(&mut self, preset: &str) -> &mut Self {
-        let mut components = TableComponent::components();
+        let mut components = TableComponent::iter();
 
         for character in preset.chars() {
             if let Some(component) = components.next() {
@@ -488,7 +488,7 @@ impl Table {
     /// assert_eq!(UTF8_FULL, table.current_style_as_preset())
     /// ```
     pub fn current_style_as_preset(&mut self) -> String {
-        let components = TableComponent::components();
+        let components = TableComponent::iter();
         let mut preset_string = String::new();
 
         for component in components {
@@ -515,7 +515,7 @@ impl Table {
     /// table.apply_modifier(UTF8_ROUND_CORNERS);
     /// ```
     pub fn apply_modifier(&mut self, modifier: &str) -> &mut Self {
-        let mut components = TableComponent::components();
+        let mut components = TableComponent::iter();
 
         for character in modifier.chars() {
             // Skip spaces while applying modifiers.

--- a/src/table.rs
+++ b/src/table.rs
@@ -7,7 +7,6 @@ use std::slice::{Iter, IterMut};
 use crossterm::terminal;
 #[cfg(feature = "tty")]
 use crossterm::tty::IsTty;
-use strum::IntoEnumIterator;
 
 use crate::cell::Cell;
 use crate::column::Column;
@@ -454,7 +453,7 @@ impl Table {
     ///
     /// If the string is too long, remaining charaacters will be simply ignored.
     pub fn load_preset(&mut self, preset: &str) -> &mut Self {
-        let mut components = TableComponent::iter();
+        let mut components = TableComponent::components();
 
         for character in preset.chars() {
             if let Some(component) = components.next() {
@@ -489,7 +488,7 @@ impl Table {
     /// assert_eq!(UTF8_FULL, table.current_style_as_preset())
     /// ```
     pub fn current_style_as_preset(&mut self) -> String {
-        let components = TableComponent::iter();
+        let components = TableComponent::components();
         let mut preset_string = String::new();
 
         for component in components {
@@ -516,7 +515,7 @@ impl Table {
     /// table.apply_modifier(UTF8_ROUND_CORNERS);
     /// ```
     pub fn apply_modifier(&mut self, modifier: &str) -> &mut Self {
-        let mut components = TableComponent::iter();
+        let mut components = TableComponent::components();
 
         for character in modifier.chars() {
             // Skip spaces while applying modifiers.


### PR DESCRIPTION
Get rid of proc-macro deps for:

* Simple dependencies
* No need to execute proc-macro (it takes some extra compile time)

@Nukesor this patch may be more like a personal preference, so it's up to you to accept. Typically, if the `TableComponent` is stable, we don't need the `EnumIter` for convenience but just finalize it.

Otherwise, I'd prefer use [enum-iterator](https://github.com/stephaneyfx/enum-iterator) who has no transitive deps and do exactly the same thing.