### PR TITLE
chore: update crossterm to 0.29

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,6 +72,6 @@ rstest = "0.25"
 [target.'cfg(not(windows))'.dependencies]
 crossterm = { version = "0.29", optional = true, default-features = false }
 [target.'cfg(windows)'.dependencies]
-crossterm = { version = "0.28", optional = true, default-features = false, features = [
+crossterm = { version = "0.29", optional = true, default-features = false, features = [
     "windows",
 ] }


### PR DESCRIPTION
In #176, I think dependabot missed the windows dependency for crossterm