### PR TITLE
Add a table width to unnecessary_max_min_constraints test so it works in environment without tty

### DIFF
--- a/tests/all/constraints_test.rs
+++ b/tests/all/constraints_test.rs
@@ -107,7 +107,9 @@ fn fixed_max_min_constraints() {
 fn unnecessary_max_min_constraints() {
     let mut table = get_constraint_table();
 
-    table.set_constraints(vec![LowerBoundary(Fixed(1)), UpperBoundary(Fixed(30))]);
+    table
+        .set_width(80)
+        .set_constraints(vec![LowerBoundary(Fixed(1)), UpperBoundary(Fixed(30))]);
 
     println!("{table}");
     let expected = "


### PR DESCRIPTION
This test is failing in our build environment which has no tty (so it returns terminal size 0). This simple fix allows the test to pass.