### PR TITLE
Add dynamic padding support

### DIFF
--- a/src/table.rs
+++ b/src/table.rs
@@ -39,6 +39,10 @@ pub struct Table {
     /// or whether only the text should be styled.
     #[cfg(feature = "tty")]
     pub(crate) style_text_only: bool,
+    // Padding between texts in adjacent cells (not including border).
+    // Unlike static padding, it considers whitespace in cell contents,
+    // and only applied when there is space.
+    smart_padding_width: u16,
 }
 
 impl fmt::Display for Table {
@@ -75,6 +79,7 @@ impl Table {
             enforce_styling: false,
             #[cfg(feature = "tty")]
             style_text_only: false,
+            smart_padding_width: 0,
         };
 
         table.load_preset(ASCII_FULL);
@@ -408,6 +413,17 @@ impl Table {
     #[cfg(feature = "tty")]
     pub fn style_text_only(&mut self) {
         self.style_text_only = true;
+    }
+
+    /// Enable smart padding for the table.
+    pub fn set_smart_padding_width(&mut self, width: u16) -> &mut Self {
+        self.smart_padding_width = width;
+        self
+    }
+
+    /// Returns smart padding count for the table.
+    pub fn smart_padding_width(&self) -> u16 {
+        self.smart_padding_width
     }
 
     /// Convenience method to set a [ColumnConstraint] for all columns at once.

--- a/src/utils/arrangement/constraint.rs
+++ b/src/utils/arrangement/constraint.rs
@@ -96,7 +96,7 @@ pub fn max(
     };
 
     match constraint {
-        UpperBoundary(width) | Boundaries { upper: width, .. } => {
+        UpperBoundary(width) | Boundaries { upper: width, .. } | Absolute(width) => {
             absolute_value_from_width(table, width, visible_columns)
         }
         _ => None,

--- a/src/utils/formatting/mod.rs
+++ b/src/utils/formatting/mod.rs
@@ -1,3 +1,4 @@
 pub mod borders;
 pub mod content_format;
 pub mod content_split;
+pub mod smart_padding;

--- a/src/utils/formatting/smart_padding.rs
+++ b/src/utils/formatting/smart_padding.rs
@@ -1,0 +1,295 @@
+use crate::Table;
+use crate::style::CellAlignment;
+use crate::style::ContentArrangement;
+use crate::style::TableComponent;
+use crate::utils::ColumnDisplayInfo;
+use crate::utils::arrangement::constraint;
+use crate::utils::arrangement::helper::*;
+
+/*
+When table has a whitespace as border, it can look quite cramped,
+especially when the cells have text with whitespaces. For example, below
+is a sample output of a certain table:
+
+     Line  User  Idle     Location
+-- ------- ----- -------- --------------------------------------
+   1 con 0 root  07:29:04 -
+   2 vty 3 root  09:12:23 10.243.214.227
+   3 vty 5 root  07:09:36 10.243.214.212
+*  4 vty 7 admin 00:00:00 fdfd:5c41:712d:d08e:2ce2:7eff:fea5:ae5
+
+As you can see most of the columns (especially the second and third) are
+separated by just a single whitespace which makes it rather hard to read.
+
+The idea of smart padding is to detect that two adjacent cells are not
+separated by enough whitespace, in which case we add one more whitespace
+between the two columns. With smart_padding_width=1 the above table would
+look like:
+
+     Line   User   Idle      Location
+-- -------- ------ --------- --------------------------------------
+   1 con 0  root   07:29:04  -
+   2 vty 3  root   09:12:23  10.243.214.227
+   3 vty 5  root   07:09:36  10.243.214.212
+*  4 vty 7  admin  00:00:00  fdfd:5c41:712d:d08e:2ce2:7eff:fea5:ae5
+
+It basically tries to make sure texts between adjacent cells have at
+least specified number of whitespaces (excluding the border).
+
+Smart padding does not take effect if one of the condition is true:
+1. There is no extra space left
+2. The left column is right aligned and the right column is left aligned
+3. The vertical border is not ' '
+ */
+
+// this is similar to available_content_width in util/arrangement/dynamic.rs
+fn available_width(table: &Table, infos: &Vec<&mut ColumnDisplayInfo>) -> u16 {
+    let mut width = match table.width() {
+        Some(width) => width as usize,
+        // Disabled arrangement, in which case treat it as MAX
+        None => return u16::MAX,
+    };
+    let visible_columns = infos.len();
+    let border_count = count_border_columns(table, visible_columns);
+    width = width.saturating_sub(border_count);
+
+    // Remove all column widths; note all hidden columns are already filtered
+    for info in infos.iter() {
+        width = width.saturating_sub(info.width().into());
+    }
+
+    u16::try_from(width).unwrap()
+}
+
+// This returns current column display width (including padding)
+fn current_column_width(info: &ColumnDisplayInfo) -> u16 {
+    info.padding.0 + info.padding.1 + info.content_width
+}
+
+// return how much more padding is available for each column if max_size is specified
+fn get_column_max_padding_widths(
+    table: &Table,
+    all_infos: &[ColumnDisplayInfo],
+    visible_columns: usize,
+) -> Vec<Option<u16>> {
+    let mut max_padding_widths = Vec::with_capacity(visible_columns);
+    for (column, info) in table.columns.iter().zip(all_infos.iter()) {
+        if info.is_hidden {
+            continue;
+        }
+        let max_width = constraint::max(table, &column.constraint, visible_columns);
+        let max_padding_width = max_width.map(|v| v.saturating_sub(current_column_width(info)));
+        max_padding_widths.push(max_padding_width);
+    }
+    max_padding_widths
+}
+
+// Whether we can pad this column on the left or right side
+fn can_pad_column(info: &ColumnDisplayInfo, position: CellAlignment) -> bool {
+    info.cell_alignment.unwrap_or(CellAlignment::Left) != position
+}
+
+// Given two adjacent cells, calculate the number of whitespaces between their texts.
+// This does not include the border inbetween.
+fn count_boundary_spaces(left: &str, right: &str) -> u16 {
+    let trailing = left.chars().rev().take_while(|c| c.is_whitespace()).count();
+    let leading = right.chars().take_while(|c| c.is_whitespace()).count();
+    u16::try_from(trailing + leading).unwrap()
+}
+
+// Given a column_index, return extra padding we need to put between the two columns
+fn compare_adjacent_columns(
+    table: &Table,
+    content: &[Vec<Vec<String>>],
+    display_infos: &[&mut ColumnDisplayInfo],
+    column_index: usize,
+    max_padding_width: u16,
+) -> u16 {
+    if !(can_pad_column(display_infos[column_index], CellAlignment::Right)
+        || can_pad_column(display_infos[column_index + 1], CellAlignment::Left))
+    {
+        return 0;
+    }
+
+    // find the most padding we need between any two adjacent cells
+    let mut padding_width = 0;
+
+    for (row_index, row) in content.iter().enumerate() {
+        if row_index == 0 && table.header().is_some() {
+            continue;
+        }
+        for sub_row in row.iter() {
+            let cell_left = &sub_row[column_index];
+            let cell_right = &sub_row[column_index + 1];
+
+            let current_padding = count_boundary_spaces(cell_left, cell_right);
+            let extra_padding = u16::saturating_sub(table.smart_padding_width(), current_padding);
+            if extra_padding >= max_padding_width {
+                // we'll need the max padding anyway
+                return max_padding_width;
+            }
+            padding_width = padding_width.max(extra_padding);
+        }
+    }
+
+    padding_width
+}
+
+// Update all cells in a certain column to add an extra padding
+fn update_column_padding(
+    content: &mut [Vec<Vec<String>>],
+    display_infos: &mut [&mut ColumnDisplayInfo],
+    max_padding_widths: &mut [Option<u16>],
+    column_index: usize,
+    padding_position: CellAlignment, // Left or Right
+    padding_needed: u16,
+) -> u16 {
+    let display_info = &display_infos[column_index];
+    if !can_pad_column(display_info, padding_position) {
+        return 0;
+    }
+
+    let padding = padding_needed.min(max_padding_widths[column_index].unwrap_or(u16::MAX));
+
+    let padding_str = " ".repeat(usize::from(padding));
+
+    // adjust the padding to make the header line consistent
+    display_infos[column_index].content_width += padding;
+    if let Some(max_padding) = &mut max_padding_widths[column_index] {
+        *max_padding = max_padding.saturating_sub(padding);
+    }
+
+    for row in content.iter_mut() {
+        for sub_row in row.iter_mut() {
+            match padding_position {
+                CellAlignment::Left => {
+                    sub_row[column_index] = format!("{}{}", padding_str, sub_row[column_index]);
+                }
+                CellAlignment::Right => {
+                    sub_row[column_index] = format!("{}{}", sub_row[column_index], padding_str);
+                }
+                _ => {
+                    unreachable!("Invalid padding position: {:?}", padding_position); // coverage:ignore-line
+                }
+            }
+        }
+    }
+    padding
+}
+
+pub fn smart_pad_content(
+    table: &Table,
+    content: &mut [Vec<Vec<String>>],
+    all_infos: &mut [ColumnDisplayInfo],
+) {
+    // Skip it for DynamicFullWidth as we most likely have enough padding
+    match &table.arrangement {
+        ContentArrangement::Disabled => (),
+        ContentArrangement::Dynamic => (),
+        _ => return,
+    }
+
+    if table.style_or_default(TableComponent::VerticalLines) != " " {
+        // if we have vertical border, no need for this padding
+        return;
+    }
+
+    if content.is_empty() || content[0].is_empty() {
+        return;
+    }
+
+    // calculate the max width for each column has it may limit how much padding each
+    // column might get
+    let mut max_padding_widths =
+        get_column_max_padding_widths(table, all_infos, content[0][0].len());
+
+    // content only has visible data, while display_infos has hidden columns.
+    // to be able to index into them correctly, let's just filter them.
+    let mut display_infos: Vec<&mut ColumnDisplayInfo> = all_infos
+        .iter_mut()
+        .filter(|info| !info.is_hidden)
+        .collect();
+
+    assert_eq!(content[0][0].len(), display_infos.len());
+
+    // get the overall available width for padding
+    let mut remaining_width = available_width(table, &display_infos);
+
+    #[cfg(feature = "_debug")]
+    println!(
+        "smartpad: available width {} visible columns {}",
+        remaining_width,
+        display_infos.len()
+    );
+
+    for column_index in 0..display_infos.len() - 1 {
+        if remaining_width == 0 {
+            return;
+        }
+
+        let max_padding_width = remaining_width
+            .min(max_padding_widths[column_index].unwrap_or(u16::MAX))
+            .max(max_padding_widths[column_index + 1].unwrap_or(u16::MAX));
+
+        // how much more we can still pad
+        let mut padding_needed = compare_adjacent_columns(
+            table,
+            content,
+            &display_infos,
+            column_index,
+            max_padding_width,
+        );
+
+        if padding_needed == 0 {
+            continue;
+        }
+
+        // We can either pad the left column or the right column
+        // prioritize left/right aligned columns (if possible)
+        // because padding center aligned column can distort the
+        // alignment.
+
+        let left_align = display_infos[column_index]
+            .cell_alignment
+            .unwrap_or(CellAlignment::Left);
+        let right_align = display_infos[column_index + 1]
+            .cell_alignment
+            .unwrap_or(CellAlignment::Left);
+
+        // By default pad left column first
+        let mut pad_order = [0, 1];
+
+        // we deprioritize center aligned as it makes the output a bit weird
+        if left_align != CellAlignment::Left && right_align == CellAlignment::Right {
+            pad_order[0] = 1;
+            pad_order[1] = 0;
+        }
+
+        for pad_index in pad_order.iter() {
+            #[cfg(feature = "_debug")]
+            println!(
+                "smartpad: column {} padding needed {}",
+                column_index + *pad_index,
+                padding_needed
+            );
+
+            let pad_position = if *pad_index == 0 {
+                CellAlignment::Right
+            } else {
+                CellAlignment::Left
+            };
+
+            let padding_done = update_column_padding(
+                content,
+                &mut display_infos,
+                &mut max_padding_widths,
+                column_index + *pad_index,
+                pad_position,
+                padding_needed,
+            );
+
+            remaining_width -= padding_done;
+            padding_needed -= padding_done;
+        }
+    }
+}

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -48,7 +48,13 @@ impl ColumnDisplayInfo {
 }
 
 pub fn build_table(table: &Table) -> impl Iterator<Item = String> {
-    let display_info = arrange_content(table);
-    let content = format_content(table, &display_info);
+    let mut display_info = arrange_content(table);
+    let mut content = format_content(table, &display_info);
+
+    if table.smart_padding_width() > 0 {
+        use formatting::smart_padding::smart_pad_content;
+        smart_pad_content(table, &mut content, &mut display_info);
+    }
+
     draw_borders(table, &content, &display_info).into_iter()
 }

--- a/tests/all/mod.rs
+++ b/tests/all/mod.rs
@@ -18,6 +18,7 @@ mod padding_test;
 mod presets_test;
 mod property_test;
 mod simple_test;
+mod smart_padding;
 #[cfg(feature = "tty")]
 mod styling_test;
 mod truncation;

--- a/tests/all/smart_padding.rs
+++ b/tests/all/smart_padding.rs
@@ -1,0 +1,375 @@
+use comfy_table::ColumnConstraint::*;
+use comfy_table::*;
+use pretty_assertions::assert_eq;
+
+const DEFAULT_TABLE_WIDTH: Option<u16> = Some(100);
+
+fn init_table(
+    table: &mut Table,
+    headers: Vec<&str>,
+    arrangement: ContentArrangement,
+    table_width: Option<u16>,
+    smart_padding_width: u16,
+) {
+    table
+        .set_content_arrangement(arrangement)
+        .load_preset(comfy_table::presets::NOTHING)
+        .set_style(comfy_table::TableComponent::HeaderLines, '-')
+        .set_style(comfy_table::TableComponent::MiddleHeaderIntersections, ' ')
+        .set_header(headers)
+        .set_smart_padding_width(smart_padding_width);
+
+    if let Some(table_width) = table_width {
+        table.set_width(table_width);
+    }
+
+    // remove padding
+    for column in table.column_iter_mut() {
+        column.set_padding((0, 0));
+    }
+}
+
+#[test]
+fn login_example() {
+    let mut table = Table::new();
+    init_table(
+        &mut table,
+        vec!["  ", "Line", "User", "Idle", "Location"],
+        ContentArrangement::Dynamic,
+        DEFAULT_TABLE_WIDTH,
+        1,
+    );
+
+    table
+        .add_row(vec!["", "1 con 0", "root", "07:29:04", "-"])
+        .add_row(vec!["", "2 vty 3", "root", "09:12:23", "10.243.214.227"])
+        .add_row(vec!["", "3 vty 5", "root", "07:09:36", "10.243.214.212"])
+        .add_row(vec![
+            "*",
+            "4 vty 7",
+            "admin",
+            "00:00:00",
+            "fdfd:5c41:712d:d08e:2ce2:7eff:fea5:ae5",
+        ]);
+
+    table
+        .column_mut(1)
+        .unwrap()
+        .set_cell_alignment(CellAlignment::Center);
+
+    println!("{table}");
+
+    let expected = [
+        "     Line   User   Idle      Location                              ",
+        "-- -------- ------ --------- --------------------------------------",
+        "   1 con 0  root   07:29:04  -                                     ",
+        "   2 vty 3  root   09:12:23  10.243.214.227                        ",
+        "   3 vty 5  root   07:09:36  10.243.214.212                        ",
+        "*  4 vty 7  admin  00:00:00  fdfd:5c41:712d:d08e:2ce2:7eff:fea5:ae5",
+    ]
+    .join("\n");
+
+    assert_eq!(table.to_string(), expected);
+}
+
+fn basic_padding_test(arrangement: ContentArrangement, table_width: Option<u16>) {
+    let mut table = Table::new();
+    init_table(
+        &mut table,
+        vec![
+            "Left", "Hidden", "Right", "Left", "Center", "Right", "Center",
+        ],
+        arrangement,
+        table_width,
+        1,
+    );
+
+    #[cfg(feature = "tty")]
+    if table_width.is_none() {
+        // this makes sure table.width() returns None
+        table.force_no_tty();
+    }
+
+    table.add_row(vec![
+        "left", "hidden", "right", "left", "center", "right", "center",
+    ]);
+
+    table
+        .column_mut(1)
+        .unwrap()
+        .set_constraint(ColumnConstraint::Hidden);
+    table
+        .column_mut(2)
+        .unwrap()
+        .set_cell_alignment(CellAlignment::Right);
+    table
+        .column_mut(4)
+        .unwrap()
+        .set_cell_alignment(CellAlignment::Center);
+    table
+        .column_mut(5)
+        .unwrap()
+        .set_cell_alignment(CellAlignment::Right);
+    table
+        .column_mut(6)
+        .unwrap()
+        .set_cell_alignment(CellAlignment::Center);
+
+    println!("{table}");
+
+    let expected = [
+        "Left  Right Left  Center  Right  Center",
+        "----- ----- ----- ------ ------ -------",
+        "left  right left  center  right  center",
+    ]
+    .join("\n");
+
+    assert_eq!(table.to_string(), expected);
+}
+
+#[test]
+fn basic_padding_dynamic() {
+    basic_padding_test(ContentArrangement::Dynamic, DEFAULT_TABLE_WIDTH);
+}
+
+#[test]
+fn basic_padding_disabled() {
+    basic_padding_test(ContentArrangement::Disabled, DEFAULT_TABLE_WIDTH);
+}
+
+#[test]
+fn basic_padding_disabled_no_width() {
+    // this is mainly for code coverage - no table width + no tty -> no width limit
+    basic_padding_test(ContentArrangement::Disabled, None);
+}
+
+#[test]
+fn table_width_limit() {
+    // verify smart padding is limited by table width
+    let mut table = Table::new();
+
+    init_table(
+        &mut table,
+        vec!["Header1", "Header2", "Header3"],
+        ContentArrangement::Dynamic,
+        Some(23),
+        1,
+    );
+    table.add_row(vec!["header1", "header2", "header3"]);
+
+    // no extra padding since the table has reached its limit
+    let expected = [
+        "Header1 Header2 Header3",
+        "------- ------- -------",
+        "header1 header2 header3",
+    ]
+    .join("\n");
+
+    assert_eq!(table.to_string(), expected);
+}
+
+#[test]
+fn column_width_limit() {
+    let mut table = Table::new();
+    init_table(
+        &mut table,
+        vec![
+            "SinglePad",
+            "Lower",
+            "Upper",
+            "DoublePad",
+            "Both",
+            "Absolute",
+        ],
+        ContentArrangement::Dynamic,
+        DEFAULT_TABLE_WIDTH,
+        1,
+    );
+
+    table
+        .add_row(vec![
+            "singlepad",
+            "lower",
+            "upper",
+            "doublepad",
+            "both",
+            "absolute",
+        ])
+        .set_constraints(vec![
+            UpperBoundary(Width::Fixed(10)), // doesn't matter
+            LowerBoundary(Width::Fixed(5)),
+            UpperBoundary(Width::Fixed(5)),
+            UpperBoundary(Width::Percentage(90)), // doesn't matter
+            Boundaries {
+                lower: Width::Fixed(2),
+                upper: Width::Fixed(4),
+            },
+            Absolute(Width::Fixed(8)),
+        ]);
+
+    table
+        .column_mut(3)
+        .unwrap()
+        .set_cell_alignment(CellAlignment::Center);
+
+    table
+        .column_mut(5)
+        .unwrap()
+        .set_cell_alignment(CellAlignment::Right);
+
+    println!("{table}");
+
+    let expected = [
+        "SinglePad  Lower  Upper  DoublePad  Both Absolute",
+        "---------- ------ ----- ----------- ---- --------",
+        "singlepad  lower  upper  doublepad  both absolute",
+    ]
+    .join("\n");
+
+    assert_eq!(table.to_string(), expected);
+}
+
+#[test]
+fn big_header() {
+    let mut table = Table::new();
+    init_table(
+        &mut table,
+        vec!["Big Header 1", "Big Header 2"],
+        ContentArrangement::Dynamic,
+        DEFAULT_TABLE_WIDTH,
+        1,
+    );
+
+    table
+        .add_row(vec!["1", "a"])
+        .add_row(vec!["2", "b"])
+        .add_row(vec!["3", "c"])
+        .add_row(vec!["4", "d"]);
+
+    println!("{table}");
+
+    // No extra space for header
+    let expected = [
+        "Big Header 1 Big Header 2",
+        "------------ ------------",
+        "1            a           ",
+        "2            b           ",
+        "3            c           ",
+        "4            d           ",
+    ]
+    .join("\n");
+
+    assert_eq!(table.to_string(), expected);
+}
+
+#[test]
+fn excessive_padding() {
+    // test smart_padding_width > 1 and with existing static padding
+    let mut table = Table::new();
+
+    init_table(
+        &mut table,
+        vec!["Max=8", "Max=10", "Max=7"],
+        ContentArrangement::Dynamic,
+        DEFAULT_TABLE_WIDTH,
+        4,
+    );
+
+    // add static padding
+    for column in table.column_iter_mut() {
+        column.set_padding((1, 1));
+    }
+
+    // set max size for the first two columns
+    table.set_constraints(vec![
+        UpperBoundary(Width::Fixed(8)),
+        UpperBoundary(Width::Fixed(10)),
+        UpperBoundary(Width::Fixed(7)),
+    ]);
+    // set the last column to be right aligned
+    table
+        .column_mut(1)
+        .unwrap()
+        .set_cell_alignment(CellAlignment::Center);
+    table
+        .column_mut(2)
+        .unwrap()
+        .set_cell_alignment(CellAlignment::Right);
+
+    table.add_row(vec!["word8", "word10", "word7"]);
+
+    // Max=8 gets no extra padding on the right
+    // Max=10 gets one extra padding on the left and one on the right
+    // Max=7 gets no extra padding
+    let expected = [
+        " Max=8     Max=10    Max=7 ",
+        "-------- ---------- -------",
+        " word8     word10    word7 ",
+    ]
+    .join("\n");
+
+    assert_eq!(table.to_string(), expected);
+}
+
+#[test]
+fn no_op_empty_table() {
+    // test empty table
+    let mut table = Table::new();
+
+    init_table(
+        &mut table,
+        vec![],
+        ContentArrangement::Dynamic,
+        DEFAULT_TABLE_WIDTH,
+        1,
+    );
+
+    assert_eq!(table.to_string(), "");
+}
+
+#[test]
+fn no_op_dynamic_full_width() {
+    // test DynamicFullWidth works as expected
+    let mut table = Table::new();
+
+    init_table(
+        &mut table,
+        vec!["Header1", "Header2"],
+        ContentArrangement::DynamicFullWidth,
+        Some(20),
+        5,
+    );
+
+    table.add_row(vec!["header1", "header2"]);
+
+    let expected = [
+        "Header1    Header2  ",
+        "---------- ---------",
+        "header1    header2  ",
+    ]
+    .join("\n");
+
+    assert_eq!(table.to_string(), expected);
+}
+
+#[test]
+fn no_op_border_not_space() {
+    // test smart-padding does not take effect when the border isn't space
+    let mut table = Table::new();
+
+    init_table(
+        &mut table,
+        vec!["Header1", "Header2"],
+        ContentArrangement::Dynamic,
+        DEFAULT_TABLE_WIDTH,
+        10,
+    );
+
+    table.set_style(comfy_table::TableComponent::VerticalLines, '|');
+
+    table.add_row(vec!["header1", "header2"]);
+
+    let expected = ["Header1|Header2", "------- -------", "header1|header2"].join("\n");
+
+    assert_eq!(table.to_string(), expected);
+}


### PR DESCRIPTION
When table has a whitespace as border, it can look quite cramped, especially when the cells have text with whitespaces. For example, below is a sample output of a certain table:

```
     Line  User  Idle     Location
-- ------- ----- -------- --------------------------------------
   1 con 0 root  07:29:04 -
   2 vty 3 root  09:12:23 10.243.214.227
   3 vty 5 root  07:09:36 10.243.214.212
*  4 vty 7 admin 00:00:00 fdfd:5c41:712d:d08e:2ce2:7eff:fea5:ae5

```
As you can see most of the columns (especially the second and third) are separated by just a single whitespace which makes it rather hard to read.

The idea of smart padding is to detect that two adjacent cells are only separated by one whitespace, in which case we add one more whitespace between the two columns. With smart_padding_width=1 the above table would look like:

```
     Line   User   Idle      Location
-- -------- ------ --------- --------------------------------------
   1 con 0  root   07:29:04  -
   2 vty 3  root   09:12:23  10.243.214.227
   3 vty 5  root   07:09:36  10.243.214.212
*  4 vty 7  admin  00:00:00  fdfd:5c41:712d:d08e:2ce2:7eff:fea5:ae5
```

It basically tries to make sure texts between adjacent cells have at least specified number of whitespaces (excluding the border).

Smart padding does not take effect if one of the condition is true:
1. There is no extra space left
2. The left column is right aligned and the right column is left aligned
3. The vertical border is not ' '