### PR TITLE
feat: add cell spanning support (colspan and rowspan)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,19 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [7.2.2] - unreleased
+## [Unreleased] - PR: Cell Spanning Feature
+
+### Added
+
+- Cell spanning support: cells can now span multiple columns (`colspan`) and/or rows (`rowspan`)
+  - `Cell::set_colspan(cols: u16)` - Set the number of columns a cell spans
+  - `Cell::set_rowspan(rows: u16)` - Set the number of rows a cell spans
+  - `Cell::colspan() -> u16` - Get the number of columns a cell spans
+  - `Cell::rowspan() -> u16` - Get the number of rows a cell spans
+  - `Cell::span_columns(cols: u16)` - Convenience alias for `set_colspan`
+  - `Cell::span_rows(rows: u16)` - Convenience alias for `set_rowspan`
+  - Cell spanning works with all table features including styling, alignment, and dynamic width arrangement
+  - Hidden columns are automatically excluded from colspan calculations
 
 ### Fix
 

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ As far as I'm aware, there're no lingering bugs and the project has a lot of tes
 - Styling Presets and preset modifiers to get you started.
 - Pretty much every part of the table is customizable (borders, lines, padding, alignment).
 - Constraints on columns that allow some additional control over how to arrange content.
+- Cell spanning (colspan and rowspan) for complex table layouts.
 - Cross platform (Linux, macOS, Windows).
 - It's fast enough.
   - Benchmarks show that a pretty big table with complex constraints is build in `470μs` or `~0.5ms`.
@@ -183,6 +184,113 @@ fn main() {
 
 This code generates the table that can be seen at the top of this document.
 
+### Cell Spanning
+
+Comfy-table supports cell spanning, allowing cells to span multiple columns (colspan) and/or rows (rowspan). This enables more complex table layouts.
+
+#### Basic Colspan Example
+
+```rust
+use comfy_table::{Cell, Table};
+
+fn main() {
+    let mut table = Table::new();
+    table
+        .set_header(vec![
+            Cell::new("Header1").set_colspan(2),
+            Cell::new("Header3"),
+        ])
+        .add_row(vec![
+            Cell::new("Spans 2 cols").set_colspan(2),
+            Cell::new("Normal cell"),
+        ]);
+
+    println!("{table}");
+}
+```
+
+```text,ignore
++----------+----------+-------------+
+| Header1             | Header3     |
++===================================+
+| Spans 2 cols        | Normal cell |
++----------+----------+-------------+
+```
+
+#### Basic Rowspan Example
+
+```rust
+use comfy_table::{Cell, Table};
+
+fn main() {
+    let mut table = Table::new();
+    table
+        .set_header(vec!["Header1", "Header2", "Header3"])
+        .add_row(vec![
+            Cell::new("Spans 2 rows").set_rowspan(2),
+            Cell::new("Cell 2"),
+            Cell::new("Cell 3"),
+        ])
+        .add_row(vec![
+            // First position is occupied by rowspan above, so only add 2 cells
+            Cell::new("Cell 2 (row 2)"),
+            Cell::new("Cell 3 (row 2)"),
+        ]);
+
+    println!("{table}");
+}
+```
+
+```text,ignore
++--------------+----------------+----------------+
+| Header1      | Header2        | Header3        |
++================================================+
+| Spans 2 rows | Cell 2         | Cell 3         |
+|              +----------------+----------------|
+|              | Cell 2 (row 2) | Cell 3 (row 2) |
++--------------+----------------+----------------+
+```
+
+#### Combined Colspan and Rowspan Example
+
+```rust
+use comfy_table::{Cell, Table};
+
+fn main() {
+    let mut table = Table::new();
+    table
+        .set_header(vec!["Header1", "Header2", "Header3", "Header4"])
+        .add_row(vec![
+            Cell::new("Spans 2x2").set_colspan(2).set_rowspan(2),
+            Cell::new("Cell 3"),
+            Cell::new("Cell 4"),
+        ])
+        .add_row(vec![
+            // First 2 positions are occupied by rowspan above
+            Cell::new("Cell 3 (row 2)"),
+            Cell::new("Cell 4 (row 2)"),
+        ]);
+
+    println!("{table}");
+}
+```
+
+```text,ignore
++---------+---------+----------------+----------------+
+| Header1 | Header2 | Header3        | Header4        |
++=====================================================+
+| Spans 2x2         | Cell 3         | Cell 4         |
+|                   +----------------+----------------|
+|                   | Cell 3 (row 2) | Cell 4 (row 2) |
++---------+---------+----------------+----------------+
+```
+
+**Notes:**
+- When using `colspan`, add fewer cells to the row than the number of columns. The spanned cell counts as multiple columns.
+- When using `rowspan`, subsequent rows should have fewer cells, as the rowspan cell occupies space in those rows.
+- You can combine `colspan` and `rowspan` to create cells that span both multiple rows and columns.
+- Cell spanning works with all table features including styling, alignment, and dynamic width arrangement.
+
 ### Code Examples
 
 A few examples can be found in the `example` folder.
@@ -229,6 +337,7 @@ Comfy-table's main focus is on being minimalistic and reliable.
 A fixed set of features that just work for "normal" use-cases:
 
 - Normal tables (columns, rows, one cell per column/row).
+- Cell spanning (colspan and rowspan) for complex layouts.
 - Dynamic arrangement of content to a given width.
 - Some kind of manual intervention in the arrangement process.
 
@@ -239,7 +348,6 @@ Some things however will most likely not be added to the project since they dras
 Such features are:
 
 - Nested tables
-- Cells that span over multiple columns/rows
 - CSV to table conversion and vice versa
 
 ## Unsafe

--- a/src/row.rs
+++ b/src/row.rs
@@ -76,6 +76,14 @@ impl Row {
         self.cells.len()
     }
 
+    /// Get the effective column count for this row, accounting for colspan.
+    ///
+    /// This sums up the colspan of all cells in the row to determine
+    /// how many column positions the row actually occupies.
+    pub(crate) fn effective_column_count(&self) -> usize {
+        self.cells.iter().map(|cell| cell.colspan() as usize).sum()
+    }
+
     /// Returns an iterator over all cells of this row
     pub fn cell_iter(&self) -> Iter<'_, Cell> {
         self.cells.iter()

--- a/src/utils/formatting/borders.rs
+++ b/src/utils/formatting/borders.rs
@@ -1,6 +1,7 @@
 use crate::style::TableComponent;
 use crate::table::Table;
 use crate::utils::ColumnDisplayInfo;
+use crate::utils::spanning::SpanTracker;
 
 pub(crate) fn draw_borders(
     table: &Table,
@@ -17,14 +18,29 @@ pub(crate) fn draw_borders(
         Vec::new()
     };
 
+    // Build span information for border drawing
+    let mut span_tracker = SpanTracker::new();
+    let header_rows = if table.header.is_some() { 1 } else { 0 };
+
     if should_draw_top_border(table) {
         lines.push(draw_top_border(table, display_info));
     }
 
-    draw_rows(&mut lines, rows, table, display_info);
+    draw_rows(
+        &mut lines,
+        rows,
+        table,
+        display_info,
+        &mut span_tracker,
+        header_rows,
+    );
 
     if should_draw_bottom_border(table) {
-        lines.push(draw_bottom_border(table, display_info));
+        // Get the last row's first line to detect colspan for bottom border
+        let last_row_line = rows
+            .last()
+            .and_then(|row| row.first().map(|line| line.as_slice()));
+        lines.push(draw_bottom_border(table, display_info, last_row_line));
     }
 
     lines
@@ -44,6 +60,7 @@ fn draw_top_border(table: &Table, display_info: &[ColumnDisplayInfo]) -> String 
 
     // Build the top border line depending on the columns' width.
     // Also add the border intersections.
+    // Top border always shows physical columns, not logical structure
     let mut first = true;
     for info in display_info.iter() {
         // Only add something, if the column isn't hidden
@@ -69,32 +86,120 @@ fn draw_rows(
     rows: &[Vec<Vec<String>>],
     table: &Table,
     display_info: &[ColumnDisplayInfo],
+    span_tracker: &mut SpanTracker,
+    header_rows: usize,
 ) {
     // Iterate over all rows
     let mut row_iter = rows.iter().enumerate().peekable();
     while let Some((row_index, row)) = row_iter.next() {
+        let actual_row_index = if row_index < header_rows {
+            row_index
+        } else {
+            row_index - header_rows
+        };
+
         // Concatenate the line parts and insert the vertical borders if needed
         for line_parts in row.iter() {
-            lines.push(embed_line(line_parts, table));
+            lines.push(embed_line(
+                line_parts,
+                table,
+                actual_row_index,
+                span_tracker,
+            ));
         }
 
         // Draw the horizontal header line if desired, otherwise continue to the next iteration
         if row_index == 0 && table.header.is_some() {
             if should_draw_header(table) {
-                lines.push(draw_horizontal_lines(table, display_info, true));
+                // Header separator should match the header content width (widest line)
+                // Draw all physical columns separately (like top border)
+                lines.push(draw_horizontal_lines(
+                    table,
+                    display_info,
+                    true,
+                    0,
+                    span_tracker,
+                    row.first().map(|line| line.as_slice()).unwrap_or(&[]),
+                ));
             }
+            // Register rowspans from header for border drawing (we only need position info, not content)
+            if let Some(header) = &table.header {
+                let mut col_index = 0;
+                for cell in &header.cells {
+                    if cell.rowspan() > 1 {
+                        span_tracker.register_rowspan(
+                            0,
+                            col_index,
+                            cell.rowspan(),
+                            cell.colspan(),
+                            None,
+                        );
+                    }
+                    col_index += cell.colspan() as usize;
+                }
+            }
+            span_tracker.advance_row(1);
             continue;
         }
 
-        // Draw a horizontal line, if we desired and if we aren't in the last row of the table.
-        if row_iter.peek().is_some() && should_draw_horizontal_lines(table) {
-            lines.push(draw_horizontal_lines(table, display_info, false));
+        // Register rowspans from data rows for border drawing
+        if actual_row_index < table.rows.len() {
+            let data_row = &table.rows[actual_row_index];
+            let mut col_index = 0;
+            for cell in &data_row.cells {
+                // Skip positions occupied by rowspan
+                while col_index < display_info.len()
+                    && span_tracker
+                        .is_col_occupied_by_rowspan(actual_row_index + header_rows, col_index)
+                {
+                    col_index += 1;
+                }
+                if col_index >= display_info.len() {
+                    break;
+                }
+                if cell.rowspan() > 1 {
+                    span_tracker.register_rowspan(
+                        actual_row_index + header_rows,
+                        col_index,
+                        cell.rowspan(),
+                        cell.colspan(),
+                        None,
+                    );
+                }
+                col_index += cell.colspan() as usize;
+            }
         }
+
+        // Draw a horizontal line, if we desired and if we aren't in the last row of the table.
+        // When drawing the border after a row, we need to check for rowspans that continue into the next row.
+        // So we check at the current row_index (the row we just processed).
+        if row_iter.peek().is_some() && should_draw_horizontal_lines(table) {
+            // Draw all physical columns separately (like top border), not based on row structure
+            let border_line = row.first().map(|line| line.as_slice()).unwrap_or(&[]);
+            // Check for rowspans at the current row_index (row we just processed)
+            // Rowspans that started at this row or earlier and still have remaining_rows should skip borders
+            lines.push(draw_horizontal_lines(
+                table,
+                display_info,
+                false,
+                actual_row_index + header_rows,
+                span_tracker,
+                border_line,
+            ));
+        }
+
+        span_tracker.advance_row(actual_row_index + header_rows + 1);
     }
 }
 
 // Takes the parts of a single line, surrounds them with borders and adds vertical lines.
-fn embed_line(line_parts: &[String], table: &Table) -> String {
+// Skips vertical borders within colspan cells (detected by empty strings).
+fn embed_line(
+    line_parts: &[String],
+    table: &Table,
+    _row_index: usize,
+    _span_tracker: &SpanTracker,
+) -> String {
     let vertical_lines = table.style_or_default(TableComponent::VerticalLines);
     let left_border = table.style_or_default(TableComponent::LeftBorder);
     let right_border = table.style_or_default(TableComponent::RightBorder);
@@ -107,9 +212,16 @@ fn embed_line(line_parts: &[String], table: &Table) -> String {
     let mut part_iter = line_parts.iter().peekable();
     while let Some(part) = part_iter.next() {
         line += part;
-        if should_draw_vertical_lines(table) && part_iter.peek().is_some() {
-            line += &vertical_lines;
-        } else if should_draw_right_border(table) && part_iter.peek().is_none() {
+        // Check if the next part exists and is not empty (empty string indicates colspan)
+        let next_part = part_iter.peek();
+        if let Some(next) = next_part {
+            // If next part is empty, it's part of a colspan - skip vertical border
+            if next.is_empty() {
+                // Skip the border for colspan
+            } else if should_draw_vertical_lines(table) {
+                line += &vertical_lines;
+            }
+        } else if should_draw_right_border(table) {
             line += &right_border;
         }
     }
@@ -118,10 +230,15 @@ fn embed_line(line_parts: &[String], table: &Table) -> String {
 }
 
 // The horizontal line that separates between rows.
+// Skips horizontal lines within rowspan cells.
+// Makes borders continuous for colspan cells.
 fn draw_horizontal_lines(
     table: &Table,
     display_info: &[ColumnDisplayInfo],
     header: bool,
+    row_index: usize,
+    span_tracker: &SpanTracker,
+    row_line: &[String],
 ) -> String {
     // Styling depends on whether we're currently on the header line or not.
     let (left_intersection, horizontal_lines, middle_intersection, right_intersection) = if header {
@@ -146,17 +263,124 @@ fn draw_horizontal_lines(
         line += &left_intersection;
     }
 
-    // Append the middle lines depending on the columns' widths.
-    // Also add the middle intersections.
+    // Draw borders following the logical structure of the preceding row.
+    // Use row_line to detect colspan: empty strings indicate colspan continuation.
+    // row_line parts correspond to visible logical columns only.
     let mut first = true;
-    for info in display_info.iter() {
-        // Only add something, if the column isn't hidden
-        if !info.is_hidden {
+    let mut visible_col_index = 0; // Index into visible columns (matches row_line index)
+
+    // Iterate through physical columns
+    let mut col_index = 0;
+    while col_index < display_info.len() {
+        let info = &display_info[col_index];
+
+        // Skip hidden columns
+        if info.is_hidden {
+            col_index += 1;
+            continue;
+        }
+
+        // Check if this column is part of a rowspan that continues into the next row
+        if let Some((_start_row, start_col, rowspan_colspan)) =
+            span_tracker.get_rowspan_start_at_row(row_index, col_index)
+        {
+            // This column is part of a rowspan, skip ALL columns in the rowspan's colspan range
+            let mut rowspan_width = 0;
+            let mut visible_cols_in_rowspan: usize = 0;
+            for i in start_col..start_col + rowspan_colspan as usize {
+                if i < display_info.len() && !display_info[i].is_hidden {
+                    rowspan_width += display_info[i].width() as usize;
+                    visible_cols_in_rowspan += 1;
+                }
+            }
+            // Add 1 character per missing separator (visible_cols_in_rowspan - 1 separators would be missing)
+            rowspan_width += visible_cols_in_rowspan.saturating_sub(1);
+            line += &" ".repeat(rowspan_width);
+            col_index = start_col + rowspan_colspan as usize;
+            // Advance visible_col_index past the rowspan columns
+            let visible_cols_skipped = display_info[start_col..col_index]
+                .iter()
+                .filter(|info| !info.is_hidden)
+                .count();
+            visible_col_index += visible_cols_skipped;
+            first = false;
+            continue;
+        }
+
+        // Check if we have a corresponding row_line part
+        if visible_col_index < row_line.len() {
+            let part = &row_line[visible_col_index];
+
+            if part.is_empty() {
+                // Empty part indicates colspan continuation - no separator, border continues
+                line += &horizontal_lines.repeat(info.width() as usize);
+                visible_col_index += 1;
+                col_index += 1;
+                continue;
+            } else {
+                // Non-empty part - this is a logical cell (possibly colspan)
+                // Calculate how many visible columns this cell spans by counting following empty parts
+                let mut colspan_visible_count = 1;
+                let mut lookahead = visible_col_index + 1;
+                while lookahead < row_line.len() && row_line[lookahead].is_empty() {
+                    colspan_visible_count += 1;
+                    lookahead += 1;
+                }
+
+                // Calculate total width for this colspan cell by summing widths of spanned columns
+                // Add 1 character per span (colspan - 1) to account for missing separator characters
+                let mut colspan_width = 0;
+                let mut temp_col = col_index;
+                let mut cols_counted = 0;
+                while cols_counted < colspan_visible_count && temp_col < display_info.len() {
+                    if !display_info[temp_col].is_hidden {
+                        colspan_width += display_info[temp_col].width() as usize;
+                        cols_counted += 1;
+                    }
+                    if cols_counted < colspan_visible_count {
+                        temp_col += 1;
+                    } else {
+                        break;
+                    }
+                }
+                // Add 1 character per missing separator (colspan - 1 separators would be missing)
+                colspan_width += colspan_visible_count - 1;
+
+                // Add separator before this logical cell (if not first)
+                if !first {
+                    line += &middle_intersection;
+                }
+                // Draw continuous border for the entire colspan
+                line += &horizontal_lines.repeat(colspan_width);
+                first = false;
+
+                // Advance past all columns in this colspan
+                visible_col_index += colspan_visible_count;
+                // Advance physical column index past the colspan
+                let mut visible_advanced = 0;
+                while visible_advanced < colspan_visible_count && col_index < display_info.len() {
+                    if !display_info[col_index].is_hidden {
+                        visible_advanced += 1;
+                    }
+                    if visible_advanced < colspan_visible_count {
+                        col_index += 1;
+                    } else {
+                        col_index += 1;
+                        break;
+                    }
+                }
+                continue;
+            }
+        } else {
+            // No more row_line parts, but we still have physical columns
+            // This shouldn't happen normally, but handle it gracefully
             if !first {
                 line += &middle_intersection;
             }
-            line += &horizontal_lines.repeat(info.width().into());
+            line += &horizontal_lines.repeat(info.width() as usize);
             first = false;
+            col_index += 1;
+            visible_col_index += 1;
         }
     }
 
@@ -168,10 +392,14 @@ fn draw_horizontal_lines(
     line
 }
 
-fn draw_bottom_border(table: &Table, display_info: &[ColumnDisplayInfo]) -> String {
+fn draw_bottom_border(
+    table: &Table,
+    display_info: &[ColumnDisplayInfo],
+    _last_row_line: Option<&[String]>,
+) -> String {
     let left_corner = table.style_or_default(TableComponent::BottomLeftCorner);
     let bottom_border = table.style_or_default(TableComponent::BottomBorder);
-    let middle_intersection = table.style_or_default(TableComponent::BottomBorderIntersections);
+    let intersection = table.style_or_default(TableComponent::BottomBorderIntersections);
     let right_corner = table.style_or_default(TableComponent::BottomRightCorner);
 
     let mut line = String::new();
@@ -180,14 +408,15 @@ fn draw_bottom_border(table: &Table, display_info: &[ColumnDisplayInfo]) -> Stri
         line += &left_corner;
     }
 
-    // Add the bottom border lines depending on column width
+    // Build the bottom border line depending on the columns' width.
     // Also add the border intersections.
+    // Bottom border always shows physical columns, matching the top border exactly
     let mut first = true;
     for info in display_info.iter() {
         // Only add something, if the column isn't hidden
         if !info.is_hidden {
             if !first {
-                line += &middle_intersection;
+                line += &intersection;
             }
             line += &bottom_border.repeat(info.width().into());
             first = false;

--- a/src/utils/formatting/content_split/custom_styling.rs
+++ b/src/utils/formatting/content_split/custom_styling.rs
@@ -1,6 +1,6 @@
 use ansi_str::AnsiStr;
 use unicode_segmentation::UnicodeSegmentation;
-use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
+use unicode_width::UnicodeWidthStr;
 
 const ANSI_RESET: &str = "\u{1b}[0m";
 

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -1,5 +1,6 @@
 pub mod arrangement;
 pub mod formatting;
+pub mod spanning;
 
 use crate::style::{CellAlignment, ColumnConstraint};
 use crate::{Column, Table};

--- a/src/utils/spanning.rs
+++ b/src/utils/spanning.rs
@@ -1,0 +1,157 @@
+use std::collections::HashMap;
+
+/// Information about an active rowspan.
+#[derive(Debug, Clone)]
+struct RowSpanInfo {
+    /// Starting row index of the span (also stored in HashMap key for lookup)
+    start_row: usize,
+    /// Number of rows remaining (decremented as we process rows)
+    remaining_rows: u16,
+    /// Number of columns this span covers
+    colspan: u16,
+    /// Cached formatted content lines for this rowspan cell (None for border drawing)
+    formatted_content: Option<Vec<String>>,
+}
+
+/// Tracks active row spans across rows during table rendering.
+#[derive(Debug, Clone, Default)]
+pub(crate) struct SpanTracker {
+    /// Maps (start_row, start_col) -> RowSpanInfo
+    active_spans: HashMap<(usize, usize), RowSpanInfo>,
+}
+
+impl SpanTracker {
+    /// Create a new empty SpanTracker.
+    pub(crate) fn new() -> Self {
+        Self {
+            active_spans: HashMap::new(),
+        }
+    }
+
+    /// Check if a position is occupied by a rowspan from a previous row.
+    ///
+    /// Returns `Some((rowspan_remaining, colspan))` if the position is occupied,
+    /// `None` otherwise.
+    pub(crate) fn is_occupied(&self, row_index: usize, col_index: usize) -> Option<(u16, u16)> {
+        for ((start_row, start_col), info) in &self.active_spans {
+            if *start_row < row_index {
+                // Check if this position falls within the colspan range
+                if *start_col <= col_index && col_index < *start_col + info.colspan as usize {
+                    return Some((info.remaining_rows, info.colspan));
+                }
+            }
+        }
+        None
+    }
+
+    /// Register a new rowspan cell with its formatted content.
+    ///
+    /// This should be called when processing a cell that has rowspan > 1.
+    /// remaining_rows is set to rowspan - 1, meaning it will appear in rowspan - 1 more rows.
+    pub(crate) fn register_rowspan(
+        &mut self,
+        row_index: usize,
+        col_index: usize,
+        rowspan: u16,
+        colspan: u16,
+        formatted_content: Option<Vec<String>>,
+    ) {
+        if rowspan > 1 {
+            self.active_spans.insert(
+                (row_index, col_index),
+                RowSpanInfo {
+                    start_row: row_index,
+                    remaining_rows: rowspan - 1, // Will appear in rowspan - 1 more rows
+                    colspan,
+                    formatted_content,
+                },
+            );
+        }
+    }
+
+    /// Get the cached formatted content for a rowspan cell.
+    ///
+    /// Returns the formatted content lines if the position is occupied by a rowspan.
+    pub(crate) fn get_rowspan_content(
+        &self,
+        row_index: usize,
+        col_index: usize,
+    ) -> Option<&Vec<String>> {
+        for ((start_row, start_col), info) in &self.active_spans {
+            if *start_row < row_index {
+                // Check if this position falls within the colspan range
+                if *start_col <= col_index && col_index < *start_col + info.colspan as usize {
+                    return info.formatted_content.as_ref();
+                }
+            }
+        }
+        None
+    }
+
+    /// Decrement rowspan counters and remove expired spans.
+    ///
+    /// This should be called after processing each row.
+    /// A rowspan is removed only after it has been displayed in all its spanned rows.
+    /// When remaining_rows reaches 0, it means the span was just displayed in its last row,
+    /// so we remove it after that row is processed.
+    pub(crate) fn advance_row(&mut self, current_row: usize) {
+        // First, remove spans that have expired (remaining_rows == 0 means it was just displayed in its last row)
+        self.active_spans.retain(|_, info| info.remaining_rows > 0);
+
+        // Then decrement remaining_rows for all active spans that have been displayed
+        // We decrement after the row has been processed, so remaining_rows represents
+        // how many more rows the span should appear in
+        for info in self.active_spans.values_mut() {
+            if info.start_row < current_row && info.remaining_rows > 0 {
+                info.remaining_rows -= 1;
+            }
+        }
+    }
+
+    /// Check if a column position is part of any active rowspan.
+    pub(crate) fn is_col_occupied_by_rowspan(&self, row_index: usize, col_index: usize) -> bool {
+        self.is_occupied(row_index, col_index).is_some()
+    }
+
+    /// Get the starting position of a rowspan that occupies the given position.
+    ///
+    /// Returns `Some((start_row, start_col, colspan))` if the position is occupied,
+    /// `None` otherwise.
+    pub(crate) fn get_rowspan_start(
+        &self,
+        row_index: usize,
+        col_index: usize,
+    ) -> Option<(usize, usize, u16)> {
+        for ((start_row, start_col), info) in &self.active_spans {
+            if *start_row < row_index {
+                // Check if this position falls within the colspan range
+                if *start_col <= col_index && col_index < *start_col + info.colspan as usize {
+                    return Some((*start_row, *start_col, info.colspan));
+                }
+            }
+        }
+        None
+    }
+
+    /// Get the starting position of a rowspan that occupies the given position at the given row.
+    /// This includes rowspans that started at the current row (for border drawing).
+    ///
+    /// Returns `Some((start_row, start_col, colspan))` if the position is occupied,
+    /// `None` otherwise.
+    pub(crate) fn get_rowspan_start_at_row(
+        &self,
+        row_index: usize,
+        col_index: usize,
+    ) -> Option<(usize, usize, u16)> {
+        for ((start_row, start_col), info) in &self.active_spans {
+            // Check if rowspan is active at this row (started at or before this row, and still has remaining rows)
+            if *start_row <= row_index && info.remaining_rows > 0 {
+                // Check if this position falls within the colspan range
+                if *start_col <= col_index && col_index < *start_col + info.colspan as usize {
+                    return Some((*start_row, *start_col, info.colspan));
+                }
+            }
+        }
+        None
+    }
+}

--- a/tests/all/mod.rs
+++ b/tests/all/mod.rs
@@ -18,6 +18,7 @@ mod padding_test;
 mod presets_test;
 mod property_test;
 mod simple_test;
+mod spanning_test;
 #[cfg(feature = "tty")]
 mod styling_test;
 mod truncation;

--- a/tests/all/spanning_test.rs
+++ b/tests/all/spanning_test.rs
@@ -1,0 +1,956 @@
+use pretty_assertions::assert_eq;
+
+use comfy_table::*;
+
+#[test]
+fn simple_colspan() {
+    let mut table = Table::new();
+    table
+        .set_header(vec![
+            Cell::new("Header1").set_colspan(2),
+            Cell::new("Header3"),
+        ])
+        .add_row(vec![
+            Cell::new("Spans 2 cols").set_colspan(2),
+            Cell::new("Normal cell"),
+        ]);
+
+    let expected = "
++----------+----------+-------------+
+| Header1             | Header3     |
++===================================+
+| Spans 2 cols        | Normal cell |
++----------+----------+-------------+";
+    assert_eq!(expected, "\n".to_string() + &table.to_string());
+}
+
+#[test]
+fn simple_rowspan() {
+    let mut table = Table::new();
+    table
+        .set_header(vec!["Header1", "Header2", "Header3"])
+        .add_row(vec![
+            Cell::new("Spans 2 rows").set_rowspan(2),
+            Cell::new("Cell 2"),
+            Cell::new("Cell 3"),
+        ])
+        .add_row(vec![
+            // First position is occupied by rowspan above, so we only add 2 cells
+            Cell::new("Cell 2 (row 2)"),
+            Cell::new("Cell 3 (row 2)"),
+        ]);
+
+    let expected = "
++--------------+----------------+----------------+
+| Header1      | Header2        | Header3        |
++================================================+
+| Spans 2 rows | Cell 2         | Cell 3         |
+|              +----------------+----------------|
+|              | Cell 2 (row 2) | Cell 3 (row 2) |
++--------------+----------------+----------------+";
+    assert_eq!(expected, "\n".to_string() + &table.to_string());
+}
+
+#[test]
+fn combined_colspan_rowspan() {
+    let mut table = Table::new();
+    table
+        .set_header(vec!["Header1", "Header2", "Header3", "Header4"])
+        .add_row(vec![
+            Cell::new("Spans 2x2").set_colspan(2).set_rowspan(2),
+            Cell::new("Cell 3"),
+            Cell::new("Cell 4"),
+        ])
+        .add_row(vec![
+            // First 2 positions are occupied by rowspan above
+            Cell::new("Cell 3 (row 2)"),
+            Cell::new("Cell 4 (row 2)"),
+        ]);
+
+    let expected = "
++---------+---------+----------------+----------------+
+| Header1 | Header2 | Header3        | Header4        |
++=====================================================+
+| Spans 2x2         | Cell 3         | Cell 4         |
+|                   +----------------+----------------|
+|                   | Cell 3 (row 2) | Cell 4 (row 2) |
++---------+---------+----------------+----------------+";
+    assert_eq!(expected, "\n".to_string() + &table.to_string());
+}
+
+#[test]
+fn multiple_spans_in_row() {
+    let mut table = Table::new();
+    table
+        .set_header(vec!["H1", "H2", "H3", "H4", "H5"])
+        .add_row(vec![
+            Cell::new("Span 2").set_colspan(2),
+            Cell::new("Normal"),
+            Cell::new("Span 2").set_colspan(2),
+        ]);
+
+    let expected = "
++------+------+--------+------+------+
+| H1   | H2   | H3     | H4   | H5   |
++====================================+
+| Span 2      | Normal | Span 2      |
++------+------+--------+------+------+";
+    assert_eq!(expected, "\n".to_string() + &table.to_string());
+}
+
+#[test]
+fn spans_in_header() {
+    let mut table = Table::new();
+    table
+        .set_header(vec![
+            Cell::new("Header spans 2").set_colspan(2),
+            Cell::new("Header3"),
+        ])
+        .add_row(vec![
+            Cell::new("Cell 1"),
+            Cell::new("Cell 2"),
+            Cell::new("Cell 3"),
+        ])
+        .add_row(vec![
+            Cell::new("Cell 1"),
+            Cell::new("Cell 2"),
+            Cell::new("Cell 3"),
+        ]);
+
+    let expected = "
++-----------+-----------+---------+
+| Header spans 2        | Header3 |
++=================================+
+| Cell 1    | Cell 2    | Cell 3  |
+|-----------+-----------+---------|
+| Cell 1    | Cell 2    | Cell 3  |
++-----------+-----------+---------+";
+    assert_eq!(expected, "\n".to_string() + &table.to_string());
+}
+
+#[test]
+fn spans_with_multiline_content() {
+    let mut table = Table::new();
+    table
+        .set_header(vec!["Header1", "Header2"])
+        .add_row(vec![
+            Cell::new("This is a\nmulti-line\ncell content").set_colspan(2),
+        ])
+        .add_row(vec![Cell::new("Cell 1"), Cell::new("Cell 2")]);
+
+    let expected = "
++---------+---------+
+| Header1 | Header2 |
++===================+
+| This is a         |
+| multi-line        |
+| cell content      |
+|-------------------|
+| Cell 1  | Cell 2  |
++---------+---------+";
+    assert_eq!(expected, "\n".to_string() + &table.to_string());
+}
+
+#[test]
+fn spans_with_different_alignments() {
+    let mut table = Table::new();
+    table
+        .set_header(vec!["H1", "H2", "H3"])
+        .add_row(vec![
+            Cell::new("Left")
+                .set_colspan(2)
+                .set_alignment(CellAlignment::Left),
+            Cell::new("Right"),
+        ])
+        .add_row(vec![
+            Cell::new("Center")
+                .set_colspan(2)
+                .set_alignment(CellAlignment::Center),
+            Cell::new("Right"),
+        ])
+        .add_row(vec![
+            Cell::new("Right")
+                .set_colspan(2)
+                .set_alignment(CellAlignment::Right),
+            Cell::new("Right"),
+        ]);
+
+    let expected = "
++------+------+-------+
+| H1   | H2   | H3    |
++=====================+
+| Left        | Right |
+|-------------+-------|
+|    Center   | Right |
+|-------------+-------|
+|       Right | Right |
++------+------+-------+";
+    assert_eq!(expected, "\n".to_string() + &table.to_string());
+}
+
+#[cfg(feature = "tty")]
+#[test]
+fn spans_with_styling() {
+    let mut table = Table::new();
+    table.set_header(vec!["H1", "H2", "H3"]).add_row(vec![
+        Cell::new("Styled span")
+            .set_colspan(2)
+            .fg(Color::Red)
+            .add_attribute(Attribute::Bold),
+        Cell::new("Normal"),
+    ]);
+    table.force_no_tty();
+
+    let expected = "
++---------+--------+--------+
+| H1      | H2     | H3     |
++===========================+
+| Styled span      | Normal |
++---------+--------+--------+";
+    assert_eq!(expected, "\n".to_string() + &table.to_string());
+}
+
+#[test]
+fn span_at_table_boundaries() {
+    let mut table = Table::new();
+    table
+        .set_header(vec!["H1", "H2"])
+        .add_row(vec![Cell::new("Spans all").set_colspan(2)]);
+
+    let expected = "
++--------+-------+
+| H1     | H2    |
++================+
+| Spans all      |
++--------+-------+";
+    assert_eq!(expected, "\n".to_string() + &table.to_string());
+}
+
+#[test]
+fn large_colspan() {
+    let mut table = Table::new();
+    table
+        .set_header(vec!["H1", "H2", "H3", "H4", "H5"])
+        .add_row(vec![Cell::new("Spans 5 cols").set_colspan(5)]);
+
+    let expected = "
++-----+-----+-----+-----+----+
+| H1  | H2  | H3  | H4  | H5 |
++============================+
+| Spans 5 cols               |
++-----+-----+-----+-----+----+";
+    assert_eq!(expected, "\n".to_string() + &table.to_string());
+}
+
+#[test]
+fn large_rowspan() {
+    let mut table = Table::new();
+    table
+        .set_header(vec!["H1", "H2", "H3"])
+        .add_row(vec![
+            Cell::new("Spans 3 rows").set_rowspan(3),
+            Cell::new("Cell 2"),
+            Cell::new("Cell 3"),
+        ])
+        .add_row(vec![
+            // First position is occupied by rowspan above
+            Cell::new("Cell 2 (row 2)"),
+            Cell::new("Cell 3 (row 2)"),
+        ])
+        .add_row(vec![
+            // First position is still occupied by rowspan
+            Cell::new("Cell 2 (row 3)"),
+            Cell::new("Cell 3 (row 3)"),
+        ]);
+
+    let expected = "
++--------------+----------------+----------------+
+| H1           | H2             | H3             |
++================================================+
+| Spans 3 rows | Cell 2         | Cell 3         |
+|              +----------------+----------------|
+|              | Cell 2 (row 2) | Cell 3 (row 2) |
+|              +----------------+----------------|
+|              | Cell 2 (row 3) | Cell 3 (row 3) |
++--------------+----------------+----------------+";
+    assert_eq!(expected, "\n".to_string() + &table.to_string());
+}
+
+#[test]
+fn rowspan_with_multiline() {
+    let mut table = Table::new();
+    table
+        .set_header(vec!["H1", "H2", "H3"])
+        .add_row(vec![
+            Cell::new("Multi\nline\nrowspan").set_rowspan(2),
+            Cell::new("Cell 2"),
+            Cell::new("Cell 3"),
+        ])
+        .add_row(vec![
+            // First position is occupied by rowspan above
+            Cell::new("Cell 2 (row 2)"),
+            Cell::new("Cell 3 (row 2)"),
+        ]);
+
+    let expected = "
++---------+----------------+----------------+
+| H1      | H2             | H3             |
++===========================================+
+| Multi   | Cell 2         | Cell 3         |
+| line    |                |                |
+| rowspan |                |                |
+|         +----------------+----------------|
+|         | Cell 2 (row 2) | Cell 3 (row 2) |
++---------+----------------+----------------+";
+    assert_eq!(expected, "\n".to_string() + &table.to_string());
+}
+
+#[test]
+fn complex_table_with_multiple_spans() {
+    let mut table = Table::new();
+    table
+        .set_header(vec![
+            Cell::new("Header 1-2").set_colspan(2),
+            Cell::new("Header 3-4").set_colspan(2),
+        ])
+        .add_row(vec![
+            Cell::new("Rowspan 1-2").set_rowspan(2),
+            Cell::new("Cell 2"),
+            Cell::new("Colspan 2").set_colspan(2),
+        ])
+        .add_row(vec![
+            // First position is occupied by rowspan above
+            Cell::new("Cell 2 (row 2)"),
+            Cell::new("Cell 3"),
+            Cell::new("Cell 4"),
+        ]);
+
+    let expected = "
++--------------+-----------------+---------+---------+
+| Header 1-2                     | Header 3-4        |
++====================================================+
+| Rowspan 1-2  | Cell 2          | Colspan 2         |
+|              +-----------------+-------------------|
+|              | Cell 2 (row 2)  | Cell 3  | Cell 4  |
++--------------+-----------------+---------+---------+";
+    assert_eq!(expected, "\n".to_string() + &table.to_string());
+}
+
+// Phase 8.2: Integration Tests
+
+#[test]
+fn spans_with_utf8_preset() {
+    let mut table = Table::new();
+    table
+        .load_preset(presets::UTF8_FULL)
+        .set_header(vec![
+            Cell::new("Header 1-2").set_colspan(2),
+            Cell::new("Header3"),
+        ])
+        .add_row(vec![
+            Cell::new("Spans 2 cols").set_colspan(2),
+            Cell::new("Normal"),
+        ]);
+
+    let output = table.to_string();
+    // UTF8 preset should use different border characters
+    assert!(output.contains("┌") || output.contains("│") || output.contains("└"));
+}
+
+#[test]
+fn spans_with_dynamic_arrangement() {
+    let mut table = Table::new();
+    table
+        .set_content_arrangement(ContentArrangement::Dynamic)
+        .set_width(40)
+        .set_header(vec![
+            Cell::new("Header 1-2").set_colspan(2),
+            Cell::new("Header3"),
+        ])
+        .add_row(vec![
+            Cell::new("Spans 2 cols with long content").set_colspan(2),
+            Cell::new("Normal"),
+        ]);
+
+    let expected = "
++--------------+---------+---------+
+| Header 1-2             | Header3 |
++==================================+
+| Spans 2 cols with long | Normal  |
+| content                |         |
++--------------+---------+---------+";
+    assert_eq!(expected, "\n".to_string() + &table.to_string());
+}
+
+#[test]
+fn spans_with_column_constraints() {
+    let mut table = Table::new();
+    table
+        .set_header(vec![
+            Cell::new("Header 1-2").set_colspan(2),
+            Cell::new("Header3"),
+        ])
+        .add_row(vec![
+            Cell::new("Spans 2 cols").set_colspan(2),
+            Cell::new("Normal"),
+        ]);
+
+    // Set constraints on columns
+    use comfy_table::Width::Fixed;
+    table
+        .column_mut(0)
+        .unwrap()
+        .set_constraint(ColumnConstraint::UpperBoundary(Fixed(10)));
+    table
+        .column_mut(1)
+        .unwrap()
+        .set_constraint(ColumnConstraint::LowerBoundary(Fixed(5)));
+    table
+        .column_mut(2)
+        .unwrap()
+        .set_constraint(ColumnConstraint::Absolute(Fixed(8)));
+
+    let expected = "
++----------+----------+--------+
+| Header 1-2          | Header |
+|                     | 3      |
++==============================+
+| Spans 2 cols        | Normal |
++----------+----------+--------+";
+    assert_eq!(expected, "\n".to_string() + &table.to_string());
+}
+
+#[test]
+fn spans_with_hidden_columns() {
+    let mut table = Table::new();
+    table
+        .set_header(vec![
+            Cell::new("Header1"),
+            Cell::new("Header2"),
+            Cell::new("Header3"),
+            Cell::new("Header4"),
+        ])
+        .add_row(vec![
+            Cell::new("Spans 2 cols").set_colspan(2),
+            Cell::new("Normal"),
+            Cell::new("Normal2"),
+        ]);
+
+    // Hide the second column (which is part of the colspan)
+    table
+        .column_mut(1)
+        .unwrap()
+        .set_constraint(ColumnConstraint::Hidden);
+
+    let expected = "
++---------+---------+---------+
+| Header1 | Header3 | Header4 |
++=============================+
+| Spans 2 | Normal  | Normal2 |
+| cols    |         |         |
++---------+---------+---------+";
+    assert_eq!(expected, "\n".to_string() + &table.to_string());
+}
+
+#[test]
+fn rowspan_with_dynamic_arrangement() {
+    let mut table = Table::new();
+    table
+        .set_content_arrangement(ContentArrangement::Dynamic)
+        .set_width(50)
+        .set_header(vec![
+            Cell::new("Header1"),
+            Cell::new("Header2"),
+            Cell::new("Header3"),
+        ])
+        .add_row(vec![
+            Cell::new("Spans 2 rows").set_rowspan(2),
+            Cell::new("Cell 2"),
+            Cell::new("Cell 3"),
+        ])
+        .add_row(vec![
+            Cell::new("Cell 2 (row 2)"),
+            Cell::new("Cell 3 (row 2)"),
+        ]);
+
+    let expected = "
++--------------+----------------+----------------+
+| Header1      | Header2        | Header3        |
++================================================+
+| Spans 2 rows | Cell 2         | Cell 3         |
+|              +----------------+----------------|
+|              | Cell 2 (row 2) | Cell 3 (row 2) |
++--------------+----------------+----------------+";
+    assert_eq!(expected, "\n".to_string() + &table.to_string());
+}
+
+#[test]
+fn combined_spans_with_constraints() {
+    let mut table = Table::new();
+    table
+        .set_header(vec![
+            Cell::new("H1"),
+            Cell::new("H2"),
+            Cell::new("H3"),
+            Cell::new("H4"),
+        ])
+        .add_row(vec![
+            Cell::new("2x2 span").set_colspan(2).set_rowspan(2),
+            Cell::new("Cell 3"),
+            Cell::new("Cell 4"),
+        ])
+        .add_row(vec![
+            Cell::new("Cell 3 (row 2)"),
+            Cell::new("Cell 4 (row 2)"),
+        ]);
+
+    // Set constraints
+    use comfy_table::Width::Fixed;
+    table
+        .column_mut(0)
+        .unwrap()
+        .set_constraint(ColumnConstraint::LowerBoundary(Fixed(8)));
+    table
+        .column_mut(2)
+        .unwrap()
+        .set_constraint(ColumnConstraint::UpperBoundary(Fixed(10)));
+
+    let expected = "
++--------+-------+----------+----------------+
+| H1     | H2    | H3       | H4             |
++============================================+
+| 2x2 span       | Cell 3   | Cell 4         |
+|                +----------+----------------|
+|                | Cell 3   | Cell 4 (row 2) |
+|                | (row 2)  |                |
++--------+-------+----------+----------------+";
+    assert_eq!(expected, "\n".to_string() + &table.to_string());
+}
+
+#[test]
+fn rowspan_with_alignment() {
+    let mut table = Table::new();
+    table
+        .set_header(vec!["H1", "H2", "H3"])
+        .add_row(vec![
+            Cell::new("Left")
+                .set_rowspan(2)
+                .set_alignment(CellAlignment::Left),
+            Cell::new("Cell 2"),
+            Cell::new("Cell 3"),
+        ])
+        .add_row(vec![
+            Cell::new("Cell 2 (row 2)"),
+            Cell::new("Cell 3 (row 2)"),
+        ])
+        .add_row(vec![
+            Cell::new("Center")
+                .set_rowspan(2)
+                .set_alignment(CellAlignment::Center),
+            Cell::new("Cell 2"),
+            Cell::new("Cell 3"),
+        ])
+        .add_row(vec![
+            Cell::new("Cell 2 (row 2)"),
+            Cell::new("Cell 3 (row 2)"),
+        ])
+        .add_row(vec![
+            Cell::new("Right")
+                .set_rowspan(2)
+                .set_alignment(CellAlignment::Right),
+            Cell::new("Cell 2"),
+            Cell::new("Cell 3"),
+        ])
+        .add_row(vec![
+            Cell::new("Cell 2 (row 2)"),
+            Cell::new("Cell 3 (row 2)"),
+        ]);
+
+    let expected = "
++--------+----------------+----------------+
+| H1     | H2             | H3             |
++==========================================+
+| Left   | Cell 2         | Cell 3         |
+|        +----------------+----------------|
+|        | Cell 2 (row 2) | Cell 3 (row 2) |
+|--------+----------------+----------------|
+| Center | Cell 2         | Cell 3         |
+|        +----------------+----------------|
+|        | Cell 2 (row 2) | Cell 3 (row 2) |
+|--------+----------------+----------------|
+|  Right | Cell 2         | Cell 3         |
+|        +----------------+----------------|
+|        | Cell 2 (row 2) | Cell 3 (row 2) |
++--------+----------------+----------------+";
+    assert_eq!(expected, "\n".to_string() + &table.to_string());
+}
+
+#[test]
+fn combined_span_with_alignment() {
+    let mut table = Table::new();
+    table
+        .set_header(vec!["H1", "H2", "H3", "H4"])
+        .add_row(vec![
+            Cell::new("Left 2x2")
+                .set_colspan(2)
+                .set_rowspan(2)
+                .set_alignment(CellAlignment::Left),
+            Cell::new("Cell 3"),
+            Cell::new("Cell 4"),
+        ])
+        .add_row(vec![
+            Cell::new("Cell 3 (row 2)"),
+            Cell::new("Cell 4 (row 2)"),
+        ])
+        .add_row(vec![
+            Cell::new("Center 2x2")
+                .set_colspan(2)
+                .set_rowspan(2)
+                .set_alignment(CellAlignment::Center),
+            Cell::new("Cell 3"),
+            Cell::new("Cell 4"),
+        ])
+        .add_row(vec![
+            Cell::new("Cell 3 (row 2)"),
+            Cell::new("Cell 4 (row 2)"),
+        ]);
+
+    let expected = "
++--------+--------+----------------+----------------+
+| H1     | H2     | H3             | H4             |
++===================================================+
+| Left 2x2        | Cell 3         | Cell 4         |
+|                 +----------------+----------------|
+|                 | Cell 3 (row 2) | Cell 4 (row 2) |
+|--------+--------+----------------+----------------|
+|    Center 2x2   | Cell 3         | Cell 4         |
+|                 +----------------+----------------|
+|                 | Cell 3 (row 2) | Cell 4 (row 2) |
++--------+--------+----------------+----------------+";
+    assert_eq!(expected, "\n".to_string() + &table.to_string());
+}
+
+#[cfg(feature = "tty")]
+#[test]
+fn rowspan_with_styling() {
+    let mut table = Table::new();
+    table
+        .set_header(vec!["H1", "H2", "H3"])
+        .add_row(vec![
+            Cell::new("Red Bold")
+                .set_rowspan(2)
+                .fg(Color::Red)
+                .add_attribute(Attribute::Bold),
+            Cell::new("Cell 2"),
+            Cell::new("Cell 3"),
+        ])
+        .add_row(vec![
+            Cell::new("Cell 2 (row 2)"),
+            Cell::new("Cell 3 (row 2)"),
+        ])
+        .add_row(vec![
+            Cell::new("Green BG")
+                .set_rowspan(2)
+                .bg(Color::Green)
+                .add_attribute(Attribute::Underlined),
+            Cell::new("Cell 2"),
+            Cell::new("Cell 3"),
+        ])
+        .add_row(vec![
+            Cell::new("Cell 2 (row 2)"),
+            Cell::new("Cell 3 (row 2)"),
+        ]);
+
+    table.force_no_tty();
+    let expected = "
++----------+----------------+----------------+
+| H1       | H2             | H3             |
++============================================+
+| Red Bold | Cell 2         | Cell 3         |
+|          +----------------+----------------|
+|          | Cell 2 (row 2) | Cell 3 (row 2) |
+|----------+----------------+----------------|
+| Green BG | Cell 2         | Cell 3         |
+|          +----------------+----------------|
+|          | Cell 2 (row 2) | Cell 3 (row 2) |
++----------+----------------+----------------+";
+    assert_eq!(expected, "\n".to_string() + &table.to_string());
+}
+
+#[cfg(feature = "tty")]
+#[test]
+fn combined_span_with_styling() {
+    let mut table = Table::new();
+    table
+        .set_header(vec!["H1", "H2", "H3", "H4"])
+        .add_row(vec![
+            Cell::new("Styled 2x2")
+                .set_colspan(2)
+                .set_rowspan(2)
+                .fg(Color::Cyan)
+                .bg(Color::Black)
+                .add_attribute(Attribute::Bold),
+            Cell::new("Cell 3"),
+            Cell::new("Cell 4"),
+        ])
+        .add_row(vec![
+            Cell::new("Cell 3 (row 2)"),
+            Cell::new("Cell 4 (row 2)"),
+        ]);
+
+    table.force_no_tty();
+    let expected = "
++--------+--------+----------------+----------------+
+| H1     | H2     | H3             | H4             |
++===================================================+
+| Styled 2x2      | Cell 3         | Cell 4         |
+|                 +----------------+----------------|
+|                 | Cell 3 (row 2) | Cell 4 (row 2) |
++--------+--------+----------------+----------------+";
+    assert_eq!(expected, "\n".to_string() + &table.to_string());
+}
+
+#[test]
+fn colspan_with_column_alignment() {
+    let mut table = Table::new();
+    table.set_header(vec!["H1", "H2", "H3", "H4"]).add_row(vec![
+        Cell::new("Spans 2 cols").set_colspan(2),
+        Cell::new("Cell 3"),
+        Cell::new("Cell 4"),
+    ]);
+
+    // Set column alignment for first two columns (which are spanned)
+    table
+        .column_mut(0)
+        .unwrap()
+        .set_cell_alignment(CellAlignment::Center);
+    table
+        .column_mut(1)
+        .unwrap()
+        .set_cell_alignment(CellAlignment::Right);
+
+    let expected = "
++---------+---------+--------+--------+
+|    H1   |      H2 | H3     | H4     |
++=====================================+
+|    Spans 2 cols   | Cell 3 | Cell 4 |
++---------+---------+--------+--------+";
+    assert_eq!(expected, "\n".to_string() + &table.to_string());
+}
+
+#[cfg(feature = "tty")]
+#[test]
+fn multiple_styled_spans() {
+    let mut table = Table::new();
+    table
+        .set_header(vec!["H1", "H2", "H3", "H4", "H5"])
+        .add_row(vec![
+            Cell::new("Red").set_colspan(2).fg(Color::Red),
+            Cell::new("Green").set_colspan(2).fg(Color::Green),
+            Cell::new("Blue").fg(Color::Blue),
+        ]);
+
+    table.force_no_tty();
+    let expected = "
++-----+----+------+-----+------+
+| H1  | H2 | H3   | H4  | H5   |
++==============================+
+| Red      | Green      | Blue |
++-----+----+------+-----+------+";
+    assert_eq!(expected, "\n".to_string() + &table.to_string());
+}
+
+#[cfg(feature = "tty")]
+#[test]
+fn span_with_multiple_attributes() {
+    let mut table = Table::new();
+    table
+        .set_header(vec!["H1", "H2", "H3"])
+        .add_row(vec![
+            Cell::new("Bold Underlined")
+                .set_colspan(2)
+                .add_attribute(Attribute::Bold)
+                .add_attribute(Attribute::Underlined),
+            Cell::new("Normal"),
+        ])
+        .add_row(vec![
+            Cell::new("Blink Italic")
+                .set_rowspan(2)
+                .add_attribute(Attribute::SlowBlink)
+                .add_attribute(Attribute::Italic),
+            Cell::new("Cell 2"),
+            Cell::new("Cell 3"),
+        ])
+        .add_row(vec![
+            Cell::new("Cell 2 (row 2)"),
+            Cell::new("Cell 3 (row 2)"),
+        ]);
+
+    table.force_no_tty();
+    let expected = "
++--------------+----------------+----------------+
+| H1           | H2             | H3             |
++================================================+
+| Bold Underlined               | Normal         |
+|-------------------------------+----------------|
+| Blink Italic | Cell 2         | Cell 3         |
+|              +----------------+----------------|
+|              | Cell 2 (row 2) | Cell 3 (row 2) |
++--------------+----------------+----------------+";
+    assert_eq!(expected, "\n".to_string() + &table.to_string());
+}
+
+#[test]
+fn span_with_alignment_and_multiline() {
+    let mut table = Table::new();
+    table
+        .set_header(vec!["H1", "H2", "H3"])
+        .add_row(vec![
+            Cell::new("Left\nMultiline")
+                .set_colspan(2)
+                .set_alignment(CellAlignment::Left),
+            Cell::new("Right"),
+        ])
+        .add_row(vec![
+            Cell::new("Center\nMultiline")
+                .set_colspan(2)
+                .set_alignment(CellAlignment::Center),
+            Cell::new("Right"),
+        ]);
+
+    let expected = "
++--------+-------+-------+
+| H1     | H2    | H3    |
++========================+
+| Left           | Right |
+| Multiline      |       |
+|----------------+-------|
+|     Center     | Right |
+|    Multiline   |       |
++--------+-------+-------+";
+    assert_eq!(expected, "\n".to_string() + &table.to_string());
+}
+
+#[test]
+fn colspan_with_custom_borders() {
+    let mut table = Table::new();
+    table
+        .set_header(vec![
+            Cell::new("Header1").set_colspan(2),
+            Cell::new("Header3"),
+        ])
+        .add_row(vec![
+            Cell::new("Spans 2 cols").set_colspan(2),
+            Cell::new("Normal"),
+        ]);
+
+    // Set custom border characters
+    use comfy_table::TableComponent::*;
+    table
+        .set_style(LeftBorder, '║')
+        .set_style(RightBorder, '║')
+        .set_style(TopLeftCorner, '╔')
+        .set_style(TopRightCorner, '╗')
+        .set_style(BottomLeftCorner, '╚')
+        .set_style(BottomRightCorner, '╝')
+        .set_style(TopBorder, '═')
+        .set_style(BottomBorder, '═')
+        .set_style(HeaderLines, '═')
+        .set_style(VerticalLines, '║')
+        .set_style(TopBorderIntersections, '╦')
+        .set_style(BottomBorderIntersections, '╩')
+        .set_style(LeftHeaderIntersection, '╠')
+        .set_style(RightHeaderIntersection, '╣')
+        .set_style(MiddleHeaderIntersections, '╬');
+
+    let expected = "
+╔══════════╦══════════╦═════════╗
+║ Header1             ║ Header3 ║
+╠═════════════════════╬═════════╣
+║ Spans 2 cols        ║ Normal  ║
+╚══════════╩══════════╩═════════╝";
+    assert_eq!(expected, "\n".to_string() + &table.to_string());
+}
+
+#[test]
+fn rowspan_with_custom_separators() {
+    let mut table = Table::new();
+    table
+        .set_header(vec!["H1", "H2", "H3"])
+        .add_row(vec![
+            Cell::new("Spans 2 rows").set_rowspan(2),
+            Cell::new("Cell 2"),
+            Cell::new("Cell 3"),
+        ])
+        .add_row(vec![
+            Cell::new("Cell 2 (row 2)"),
+            Cell::new("Cell 3 (row 2)"),
+        ]);
+
+    // Set custom separator characters
+    use comfy_table::TableComponent::*;
+    table
+        .set_style(RightBorder, '┤')
+        .set_style(VerticalLines, '│')
+        .set_style(MiddleIntersections, '┼')
+        .set_style(LeftBorderIntersections, '├')
+        .set_style(RightBorderIntersections, '┤');
+
+    let expected = "
++--------------+----------------+----------------+
+| H1           │ H2             │ H3             ┤
++================================================+
+| Spans 2 rows │ Cell 2         │ Cell 3         ┤
+├              ┼----------------┼----------------┤
+|              │ Cell 2 (row 2) │ Cell 3 (row 2) ┤
++--------------+----------------+----------------+";
+    assert_eq!(expected, "\n".to_string() + &table.to_string());
+}
+
+#[test]
+fn combined_span_with_custom_borders_and_separators() {
+    let mut table = Table::new();
+    table
+        .set_header(vec!["H1", "H2", "H3", "H4"])
+        .add_row(vec![
+            Cell::new("2x2 span").set_colspan(2).set_rowspan(2),
+            Cell::new("Cell 3"),
+            Cell::new("Cell 4"),
+        ])
+        .add_row(vec![
+            Cell::new("Cell 3 (row 2)"),
+            Cell::new("Cell 4 (row 2)"),
+        ]);
+
+    // Set custom border and separator characters
+    use comfy_table::TableComponent::*;
+    table
+        .set_style(LeftBorder, '│')
+        .set_style(RightBorder, '│')
+        .set_style(TopLeftCorner, '┌')
+        .set_style(TopRightCorner, '┐')
+        .set_style(BottomLeftCorner, '└')
+        .set_style(BottomRightCorner, '┘')
+        .set_style(TopBorder, '─')
+        .set_style(BottomBorder, '─')
+        .set_style(HeaderLines, '═')
+        .set_style(VerticalLines, '│')
+        .set_style(TopBorderIntersections, '┬')
+        .set_style(BottomBorderIntersections, '┴')
+        .set_style(MiddleIntersections, '┼')
+        .set_style(LeftBorderIntersections, '├')
+        .set_style(RightBorderIntersections, '┤')
+        .set_style(LeftHeaderIntersection, '╞')
+        .set_style(RightHeaderIntersection, '╡')
+        .set_style(MiddleHeaderIntersections, '╪');
+
+    let expected = "
+┌───────┬───────┬────────────────┬────────────────┐
+│ H1    │ H2    │ H3             │ H4             │
+╞═══════╪═══════╪════════════════╪════════════════╡
+│ 2x2 span      │ Cell 3         │ Cell 4         │
+├               ┼----------------┼----------------┤
+│               │ Cell 3 (row 2) │ Cell 4 (row 2) │
+└───────┴───────┴────────────────┴────────────────┘";
+    assert_eq!(expected, "\n".to_string() + &table.to_string());
+}


### PR DESCRIPTION
This commit adds comprehensive support for cell spanning, allowing cells to span multiple columns (colspan) and/or rows (rowspan). This enables more complex table layouts while maintaining backward compatibility.

Features:
- Cell::set_colspan(cols: u16) and Cell::set_rowspan(rows: u16) methods
- Cell::colspan() and Cell::rowspan() getters
- Convenience aliases: Cell::span_columns() and Cell::span_rows()
- Full integration with existing features:
  * Styling (colors, attributes)
  * Alignment (left, center, right)
  * Dynamic width arrangement
  * Column constraints
  * Hidden columns
  * Custom borders and separators
  * Multi-line content

Implementation details:
- Added SpanTracker utility to manage active rowspans across rows
- Updated content formatting to handle colspan and rowspan
- Modified border drawing to correctly render spans
- Enhanced column width calculation to account for spans
- Rowspan content appears only in the starting row

Testing:
- 30 comprehensive test cases covering:
  * Basic colspan and rowspan
  * Combined spans
  * Spans with styling and alignment
  * Spans with constraints and hidden columns
  * Custom borders and separators
  * Edge cases and complex scenarios

Documentation:
- Updated README with examples and usage notes
- Enhanced API documentation with examples
- Updated CHANGELOG

Future idea:
- Add vertical alignment to rowspan cells
