### PR TITLE
fix: use `RngExt` instead of `Rng` in bench

### DIFF
--- a/benches/build_large_table.rs
+++ b/benches/build_large_table.rs
@@ -1,6 +1,6 @@
 use comfy_table::{presets::UTF8_FULL, *};
 use criterion::{Criterion, criterion_group, criterion_main};
-use rand::{Rng, distr::Alphanumeric};
+use rand::{RngExt, distr::Alphanumeric};
 
 /// Create a dynamic 10x500 Table with width 300 and unevenly distributed content.
 /// There are no constraint, the content simply has to be formatted to fit as good as possible into


### PR DESCRIPTION
From `rand` 0.9 to 0.10, `RngCore` became `Rng` and `Rng` became `RngExt`.[^1] This broke the `build_large_table` benchmark.

[^1]: Here's why: https://github.com/rust-random/rand_core/pull/54