### PR TITLE
fix: zero-width "Hollow Terminal" breaks column layout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Fix
 
+- Fixed broken column layout in zero-width terminal environments (e.g. Nix build sandbox). [#210](https://github.com/Nukesor/comfy-table/pull/210)
+
 ## [7.2.2] - 2026-01-13
 
 ### Fix

--- a/src/utils/arrangement/mod.rs
+++ b/src/utils/arrangement/mod.rs
@@ -36,12 +36,14 @@ pub fn arrange_content(table: &Table) -> Vec<ColumnDisplayInfo> {
     println!("After initial constraints: {infos:#?}");
 
     // Fallback to `ContentArrangement::Disabled`, if we don't have any information
-    // on how wide the table should be.
-    let table_width = if let Some(table_width) = table_width {
-        table_width
-    } else {
-        disabled::arrange(table, &mut infos, visible_columns, &max_content_widths);
-        return infos.into_values().collect();
+    // on how wide the table should be, or if the detected width is zero
+    // ("Hollow Terminal": a tty exists but reports no dimensions).
+    let table_width = match table_width {
+        Some(0) | None => {
+            disabled::arrange(table, &mut infos, visible_columns, &max_content_widths);
+            return infos.into_values().collect();
+        }
+        Some(width) => width,
     };
 
     match &table.arrangement {

--- a/tests/all/content_arrangement_test.rs
+++ b/tests/all/content_arrangement_test.rs
@@ -289,3 +289,25 @@ fn polar_python_test_tbl_width_chars() {
     assert_table_line_width(table, 72);
     assert_eq!(expected, "\n".to_string() + &table.to_string());
 }
+
+/// Regression test for zero-width "Hollow Terminal" (e.g. Nix sandbox pts).
+#[test]
+fn hollow_terminal_zero_width_falls_back_to_disabled() {
+    let mut table = Table::new();
+    table
+        .set_content_arrangement(ContentArrangement::Dynamic)
+        .set_width(0)
+        .set_header(vec!["head1", "head2"])
+        .add_row(vec!["one", "two"]);
+
+    println!("{table}");
+    let expected = "
++-------+-------+
+| head1 | head2 |
++===============+
+| one   | two   |
++-------+-------+";
+    println!("{expected}");
+    assert_table_line_width(&table, 17);
+    assert_eq!(expected, "\n".to_string() + &table.to_string());
+}


### PR DESCRIPTION
Found while packaging Fluree DB (a Rust graph database that uses comfy-table for CLI output) for Nix. In the Nix build sandbox, stdout is a pseudo-terminal that exists (`is_terminal()` returns `true`) but has no real dimensions (`crossterm::terminal::size()` returns `Ok((0, 0))`). `Table::width()` then returns `Some(0)`, which `arrange_content()` treated as a valid width, producing columns with only 1 content character.

I'm calling this "Hollow Terminal" -- the shell exists, the inside is empty -- following [Gerald Jay Sussman's advice](https://youtu.be/2MYzvQ1v8Ww?t=1400) that interesting bugs deserve names.

@hzhongmj reported this same bug class in #186 (rpmbuild environment, "control terminal is valid but has size (0,0)"). That PR patched one test with an explicit `set_width`, but I think this is the structural fix: `Some(0) | None` → both fall back to `ContentArrangement::Disabled`.

All 116 tests pass, `cargo fmt --check` and `cargo clippy` clean.

Assisted-by: Syzygy(qswsnkmv)/OpenCode(1.17.9):zai-coding-plan/glm-5.2